### PR TITLE
(feat) add flush consolidation handler

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -149,6 +149,18 @@
             <version>1.8.5</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.openjdk.jmh</groupId>
+            <artifactId>jmh-core</artifactId>
+            <version>1.20</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.openjdk.jmh</groupId>
+            <artifactId>jmh-generator-annprocess</artifactId>
+            <version>1.20</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/src/main/java/com/alipay/remoting/config/switches/GlobalSwitch.java
+++ b/src/main/java/com/alipay/remoting/config/switches/GlobalSwitch.java
@@ -38,6 +38,7 @@ public class GlobalSwitch implements Switch {
     public static final int CONN_MONITOR_SWITCH             = 1;
     public static final int SERVER_MANAGE_CONNECTION_SWITCH = 2;
     public static final int SERVER_SYNC_STOP                = 3;
+    public static final int CODEC_FLUSH_CONSOLIDATION       = 4;
 
     /** user settings */
     private BitSet          userSettings                    = new BitSet();

--- a/src/test/java/com/alipay/remoting/benchmark/BenchmarkClient.java
+++ b/src/test/java/com/alipay/remoting/benchmark/BenchmarkClient.java
@@ -1,0 +1,151 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alipay.remoting.benchmark;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Random;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicLong;
+
+import com.alipay.remoting.config.switches.GlobalSwitch;
+import com.alipay.remoting.exception.RemotingException;
+import com.alipay.remoting.rpc.RpcClient;
+import com.alipay.remoting.rpc.RpcResponseFuture;
+
+/**
+ * @author jiachun.fjc
+ */
+public class BenchmarkClient {
+
+    /**
+     * body=4096, CODEC_FLUSH_CONSOLIDATION=turnOff
+     * Request count: 10240000, time: 347 second, qps: 29510
+     *
+     * body=4096, CODEC_FLUSH_CONSOLIDATION=turnOn
+     * Request count: 10240000, time: 311 second, qps: 32926
+     *
+     * -------------------------------------------------------
+     *
+     * body=1024, CODEC_FLUSH_CONSOLIDATION=turnOff
+     * Request count: 10240000, time: 206 second, qps: 49708
+     *
+     * body=1024, CODEC_FLUSH_CONSOLIDATION=turnOn
+     * Request count: 10240000, time: 148 second, qps: 69189
+     *
+     * -------------------------------------------------------
+     *
+     * body=128, CODEC_FLUSH_CONSOLIDATION=turnOff
+     * Request count: 10240000, time: 148 second, qps: 69189
+     *
+     * body=128, CODEC_FLUSH_CONSOLIDATION=turnOn
+     * Request count: 10240000, time: 69 second, qps: 148405
+     *
+     */
+
+    private static final byte[] BYTES = new byte[128];
+
+    static {
+        new Random().nextBytes(BYTES);
+    }
+
+    public static void main(String[] args) throws RemotingException, InterruptedException {
+        System.setProperty("bolt.netty.buffer.high.watermark", String.valueOf(64 * 1024 * 1024));
+        System.setProperty("bolt.netty.buffer.low.watermark", String.valueOf(32 * 1024 * 1024));
+        RpcClient rpcClient = new RpcClient();
+        rpcClient.switches().turnOn(GlobalSwitch.CODEC_FLUSH_CONSOLIDATION);
+        rpcClient.startup();
+
+        int processors = Runtime.getRuntime().availableProcessors();
+        callWithFuture(rpcClient, "127.0.0.1:18090", processors << 4);
+    }
+
+    @SuppressWarnings("SameParameterValue")
+    private static void callWithFuture(final RpcClient rpcClient, final String address, int threads) {
+        // warmup
+        for (int i = 0; i < 10000; i++) {
+            try {
+                RpcResponseFuture f = rpcClient.invokeWithFuture(address,
+                    new Request<byte[]>(BYTES), 5000);
+                f.get();
+            } catch (Throwable e) {
+                e.printStackTrace();
+            }
+        }
+
+        final int t = 80000;
+        long start = System.currentTimeMillis();
+        final CountDownLatch latch = new CountDownLatch(threads);
+        final AtomicLong count = new AtomicLong();
+        final int futureSize = 80;
+        for (int i = 0; i < threads; i++) {
+            new Thread(new Runnable() {
+
+                List<RpcResponseFuture> futures = new ArrayList<RpcResponseFuture>(futureSize);
+
+                @Override
+                public void run() {
+                    for (int i = 0; i < t; i++) {
+                        try {
+                            RpcResponseFuture f = rpcClient.invokeWithFuture(address,
+                                new Request<byte[]>(BYTES), 5000);
+                            futures.add(f);
+                            if (futures.size() == futureSize) {
+                                int fSize = futures.size();
+                                for (int j = 0; j < fSize; j++) {
+                                    try {
+                                        futures.get(j).get();
+                                    } catch (Throwable t) {
+                                        t.printStackTrace();
+                                    }
+                                }
+                                futures.clear();
+                            }
+                            if (count.getAndIncrement() % 10000 == 0) {
+                                System.out.println("count=" + count.get());
+                            }
+                        } catch (Exception e) {
+                            e.printStackTrace();
+                        }
+                    }
+                    if (!futures.isEmpty()) {
+                        int fSize = futures.size();
+                        for (int j = 0; j < fSize; j++) {
+                            try {
+                                futures.get(j).get();
+                            } catch (Throwable t) {
+                                t.printStackTrace();
+                            }
+                        }
+                        futures.clear();
+                    }
+                    latch.countDown();
+                }
+            }, "benchmark_" + i).start();
+        }
+
+        try {
+            latch.await();
+            System.out.println("count=" + count.get());
+        } catch (InterruptedException e) {
+            e.printStackTrace();
+        }
+        long second = (System.currentTimeMillis() - start) / 1000;
+        System.out.println("Request count: " + count.get() + ", time: " + second + " second, qps: "
+                           + count.get() / second);
+    }
+}

--- a/src/test/java/com/alipay/remoting/benchmark/BenchmarkServer.java
+++ b/src/test/java/com/alipay/remoting/benchmark/BenchmarkServer.java
@@ -1,0 +1,35 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alipay.remoting.benchmark;
+
+import com.alipay.remoting.config.switches.GlobalSwitch;
+import com.alipay.remoting.rpc.RpcServer;
+
+/**
+ * @author jiachun.fjc
+ */
+public class BenchmarkServer {
+
+    public static void main(String[] args) {
+        System.setProperty("bolt.netty.buffer.high.watermark", String.valueOf(64 * 1024 * 1024));
+        System.setProperty("bolt.netty.buffer.low.watermark", String.valueOf(32 * 1024 * 1024));
+        RpcServer rpcServer = new RpcServer(18090, true, true);
+        rpcServer.switches().turnOn(GlobalSwitch.CODEC_FLUSH_CONSOLIDATION);
+        rpcServer.registerUserProcessor(new BenchmarkUserProcessor());
+        rpcServer.startup();
+    }
+}

--- a/src/test/java/com/alipay/remoting/benchmark/BenchmarkUserProcessor.java
+++ b/src/test/java/com/alipay/remoting/benchmark/BenchmarkUserProcessor.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alipay.remoting.benchmark;
+
+import com.alipay.remoting.AsyncContext;
+import com.alipay.remoting.BizContext;
+import com.alipay.remoting.rpc.protocol.AsyncUserProcessor;
+
+/**
+ *
+ * @author jiachun.fjc
+ */
+public class BenchmarkUserProcessor extends AsyncUserProcessor<Request> {
+
+    @Override
+    public void handleRequest(BizContext bizCtx, AsyncContext asyncCtx, Request request) {
+        asyncCtx.sendResponse(request.getData());
+    }
+
+    @Override
+    public String interest() {
+        return Request.class.getName();
+    }
+}

--- a/src/test/java/com/alipay/remoting/benchmark/JMHBenchmarkClient.java
+++ b/src/test/java/com/alipay/remoting/benchmark/JMHBenchmarkClient.java
@@ -1,0 +1,111 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alipay.remoting.benchmark;
+
+import java.util.Random;
+import java.util.concurrent.TimeUnit;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+import org.openjdk.jmh.runner.options.TimeValue;
+
+import com.alipay.remoting.config.switches.GlobalSwitch;
+import com.alipay.remoting.exception.RemotingException;
+import com.alipay.remoting.rpc.RpcClient;
+
+/**
+ * @author jiachun.fjc
+ */
+@State(Scope.Benchmark)
+public class JMHBenchmarkClient {
+
+    /**
+     * CODEC_FLUSH_CONSOLIDATION=turnOn
+     * Benchmark                     Mode  Cnt   Score    Error   Units
+     * JMHBenchmarkClient.send1024  thrpt    3  51.310 ± 11.585  ops/ms
+     * JMHBenchmarkClient.send128   thrpt    3  68.493 ± 20.078  ops/ms
+     *
+     * CODEC_FLUSH_CONSOLIDATION=turnOff
+     * Benchmark                     Mode  Cnt   Score    Error   Units
+     * JMHBenchmarkClient.send1024  thrpt    3  37.769 ± 31.279  ops/ms
+     * JMHBenchmarkClient.send128   thrpt    3  44.074 ± 32.570  ops/ms
+     */
+
+    public static final int     CONCURRENCY = 32;
+
+    private static final byte[] BYTES_128   = new byte[128];
+    private static final byte[] BYTES_1024  = new byte[1024];
+
+    static {
+        new Random().nextBytes(BYTES_128);
+        new Random().nextBytes(BYTES_1024);
+    }
+
+    private RpcClient           client;
+
+    @Setup
+    public void setup() {
+        System.setProperty("bolt.netty.buffer.high.watermark", String.valueOf(64 * 1024 * 1024));
+        System.setProperty("bolt.netty.buffer.low.watermark", String.valueOf(32 * 1024 * 1024));
+        client = new RpcClient();
+        client.switches().turnOn(GlobalSwitch.CODEC_FLUSH_CONSOLIDATION);
+        client.startup();
+    }
+
+    @TearDown
+    public void tearDown() {
+        client.shutdown();
+    }
+
+    @Benchmark
+    @BenchmarkMode(Mode.Throughput)
+    @OutputTimeUnit(TimeUnit.MILLISECONDS)
+    public void send128() throws RemotingException, InterruptedException {
+        client.invokeSync("127.0.0.1:18090", new Request<byte[]>(BYTES_128), 5000);
+    }
+
+    @Benchmark
+    @BenchmarkMode(Mode.Throughput)
+    @OutputTimeUnit(TimeUnit.MILLISECONDS)
+    public void send1024() throws RemotingException, InterruptedException {
+        client.invokeSync("127.0.0.1:18090", new Request<byte[]>(BYTES_1024), 5000);
+    }
+
+    public static void main(String[] args) throws RunnerException {
+        Options opt = new OptionsBuilder()//
+            .include(JMHBenchmarkClient.class.getSimpleName())//
+            .warmupIterations(3)//
+            .warmupTime(TimeValue.seconds(10))//
+            .measurementIterations(3)//
+            .measurementTime(TimeValue.seconds(10))//
+            .threads(CONCURRENCY)//
+            .forks(1)//
+            .build();
+
+        new Runner(opt).run();
+    }
+}

--- a/src/test/java/com/alipay/remoting/benchmark/JMHBenchmarkClient.java
+++ b/src/test/java/com/alipay/remoting/benchmark/JMHBenchmarkClient.java
@@ -45,14 +45,58 @@ public class JMHBenchmarkClient {
 
     /**
      * CODEC_FLUSH_CONSOLIDATION=turnOn
-     * Benchmark                     Mode  Cnt   Score    Error   Units
-     * JMHBenchmarkClient.send1024  thrpt    3  51.310 ± 11.585  ops/ms
-     * JMHBenchmarkClient.send128   thrpt    3  68.493 ± 20.078  ops/ms
+     * Benchmark                                       Mode      Cnt   Score    Error   Units
+     * JMHBenchmarkClient.send1024                    thrpt        3  46.887 ± 22.766  ops/ms
+     * JMHBenchmarkClient.send128                     thrpt        3  66.376 ± 28.429  ops/ms
+     * JMHBenchmarkClient.send1024                     avgt        3   0.674 ±  0.986   ms/op
+     * JMHBenchmarkClient.send128                      avgt        3   0.479 ±  0.239   ms/op
+     * JMHBenchmarkClient.send1024                   sample  1525751   0.629 ±  0.001   ms/op
+     * JMHBenchmarkClient.send1024:send1024·p0.00    sample            0.150            ms/op
+     * JMHBenchmarkClient.send1024:send1024·p0.50    sample            0.602            ms/op
+     * JMHBenchmarkClient.send1024:send1024·p0.90    sample            0.775            ms/op
+     * JMHBenchmarkClient.send1024:send1024·p0.95    sample            0.854            ms/op
+     * JMHBenchmarkClient.send1024:send1024·p0.99    sample            1.614            ms/op
+     * JMHBenchmarkClient.send1024:send1024·p0.999   sample            2.249            ms/op
+     * JMHBenchmarkClient.send1024:send1024·p0.9999  sample            4.280            ms/op
+     * JMHBenchmarkClient.send1024:send1024·p1.00    sample            6.431            ms/op
+     * JMHBenchmarkClient.send128                    sample  1913189   0.501 ±  0.001   ms/op
+     * JMHBenchmarkClient.send128:send128·p0.00      sample            0.150            ms/op
+     * JMHBenchmarkClient.send128:send128·p0.50      sample            0.481            ms/op
+     * JMHBenchmarkClient.send128:send128·p0.90      sample            0.618            ms/op
+     * JMHBenchmarkClient.send128:send128·p0.95      sample            0.688            ms/op
+     * JMHBenchmarkClient.send128:send128·p0.99      sample            1.190            ms/op
+     * JMHBenchmarkClient.send128:send128·p0.999     sample            2.097            ms/op
+     * JMHBenchmarkClient.send128:send128·p0.9999    sample            4.391            ms/op
+     * JMHBenchmarkClient.send128:send128·p1.00      sample            7.053            ms/op
+     * JMHBenchmarkClient.send1024                       ss        3   5.179 ± 18.142   ms/op
+     * JMHBenchmarkClient.send128                        ss        3   3.788 ± 10.388   ms/op
      *
      * CODEC_FLUSH_CONSOLIDATION=turnOff
-     * Benchmark                     Mode  Cnt   Score    Error   Units
-     * JMHBenchmarkClient.send1024  thrpt    3  37.769 ± 31.279  ops/ms
-     * JMHBenchmarkClient.send128   thrpt    3  44.074 ± 32.570  ops/ms
+     * Benchmark                                       Mode      Cnt   Score    Error   Units
+     * JMHBenchmarkClient.send1024                    thrpt        3  35.946 ± 10.332  ops/ms
+     * JMHBenchmarkClient.send128                     thrpt        3  41.364 ± 36.002  ops/ms
+     * JMHBenchmarkClient.send1024                     avgt        3   0.846 ±  0.272   ms/op
+     * JMHBenchmarkClient.send128                      avgt        3   0.731 ±  0.306   ms/op
+     * JMHBenchmarkClient.send1024                   sample  1003714   0.956 ±  0.001   ms/op
+     * JMHBenchmarkClient.send1024:send1024·p0.00    sample            0.183            ms/op
+     * JMHBenchmarkClient.send1024:send1024·p0.50    sample            0.886            ms/op
+     * JMHBenchmarkClient.send1024:send1024·p0.90    sample            1.294            ms/op
+     * JMHBenchmarkClient.send1024:send1024·p0.95    sample            1.495            ms/op
+     * JMHBenchmarkClient.send1024:send1024·p0.99    sample            2.241            ms/op
+     * JMHBenchmarkClient.send1024:send1024·p0.999   sample            3.977            ms/op
+     * JMHBenchmarkClient.send1024:send1024·p0.9999  sample            8.448            ms/op
+     * JMHBenchmarkClient.send1024:send1024·p1.00    sample           21.660            ms/op
+     * JMHBenchmarkClient.send128                    sample  1346879   0.712 ±  0.001   ms/op
+     * JMHBenchmarkClient.send128:send128·p0.00      sample            0.124            ms/op
+     * JMHBenchmarkClient.send128:send128·p0.50      sample            0.684            ms/op
+     * JMHBenchmarkClient.send128:send128·p0.90      sample            0.927            ms/op
+     * JMHBenchmarkClient.send128:send128·p0.95      sample            1.016            ms/op
+     * JMHBenchmarkClient.send128:send128·p0.99      sample            1.571            ms/op
+     * JMHBenchmarkClient.send128:send128·p0.999     sample            2.322            ms/op
+     * JMHBenchmarkClient.send128:send128·p0.9999    sample            4.375            ms/op
+     * JMHBenchmarkClient.send128:send128·p1.00      sample            5.865            ms/op
+     * JMHBenchmarkClient.send1024                       ss        3   5.932 ± 13.160   ms/op
+     * JMHBenchmarkClient.send128                        ss        3   5.028 ± 10.273   ms/op
      */
 
     public static final int     CONCURRENCY = 32;
@@ -82,14 +126,14 @@ public class JMHBenchmarkClient {
     }
 
     @Benchmark
-    @BenchmarkMode(Mode.Throughput)
+    @BenchmarkMode(Mode.All)
     @OutputTimeUnit(TimeUnit.MILLISECONDS)
     public void send128() throws RemotingException, InterruptedException {
         client.invokeSync("127.0.0.1:18090", new Request<byte[]>(BYTES_128), 5000);
     }
 
     @Benchmark
-    @BenchmarkMode(Mode.Throughput)
+    @BenchmarkMode(Mode.All)
     @OutputTimeUnit(TimeUnit.MILLISECONDS)
     public void send1024() throws RemotingException, InterruptedException {
         client.invokeSync("127.0.0.1:18090", new Request<byte[]>(BYTES_1024), 5000);

--- a/src/test/java/com/alipay/remoting/benchmark/Request.java
+++ b/src/test/java/com/alipay/remoting/benchmark/Request.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alipay.remoting.benchmark;
+
+import java.io.Serializable;
+
+/**
+ *
+ * @author jiachun.fjc
+ */
+public class Request<T> implements Serializable {
+
+    private static final long serialVersionUID = -1L;
+
+    public Request(T data) {
+        this.data = data;
+    }
+
+    private T data;
+
+    public T getData() {
+        return data;
+    }
+
+    public void setData(T data) {
+        this.data = data;
+    }
+}


### PR DESCRIPTION
Flush operations are generally speaking expensive as these may trigger a syscall on the transport level.
Thus it is in most cases a good idea to try to minimize flush operations as much as possible.