### PR TITLE
handling reconnection situation with no connection binding with channel

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,8 @@ jdk:
   - oraclejdk8
   - openjdk7
 
+dist: trusty
+
 before_install:
   - echo "Downloading Maven 3.2.5"
    && wget https://archive.apache.org/dist/maven/maven-3/3.2.5/binaries/apache-maven-3.2.5-bin.zip

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.alipay.sofa</groupId>
     <artifactId>bolt</artifactId>
-    <version>1.6.0</version>
+    <version>1.6.1-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>${project.groupId}:${project.artifactId}</name>

--- a/src/main/java/com/alipay/remoting/ConnectionEventType.java
+++ b/src/main/java/com/alipay/remoting/ConnectionEventType.java
@@ -23,5 +23,5 @@ package com.alipay.remoting;
  * @version $Id: ConnectionEventType.java, v 0.1 Mar 4, 2016 8:03:27 PM tao Exp $
  */
 public enum ConnectionEventType {
-    CONNECT, CLOSE, EXCEPTION;
+    CONNECT, CONNECT_FAILED, CLOSE, EXCEPTION;
 }

--- a/src/main/java/com/alipay/remoting/DefaultConnectionManager.java
+++ b/src/main/java/com/alipay/remoting/DefaultConnectionManager.java
@@ -425,7 +425,14 @@ public class DefaultConnectionManager extends AbstractLifeCycle implements Conne
             Iterator<String> iter = this.connTasks.keySet().iterator();
             while (iter.hasNext()) {
                 String poolKey = iter.next();
-                ConnectionPool pool = this.getConnectionPool(this.connTasks.get(poolKey));
+                RunStateRecordedFutureTask<ConnectionPool> task = this.connTasks.get(poolKey);
+                if (!task.isDone()) {
+                    logger.info("task(poolKey={}) is not done, do not scan the connection pool",
+                        poolKey);
+                    continue;
+                }
+
+                ConnectionPool pool = this.getConnectionPool(task);
                 if (null != pool) {
                     pool.scan();
                     if (pool.isEmpty()) {

--- a/src/main/java/com/alipay/remoting/connection/AbstractConnectionFactory.java
+++ b/src/main/java/com/alipay/remoting/connection/AbstractConnectionFactory.java
@@ -139,7 +139,11 @@ public abstract class AbstractConnectionFactory implements ConnectionFactory {
         Channel channel = doCreateConnection(url.getIp(), url.getPort(), url.getConnectTimeout());
         Connection conn = new Connection(channel, ProtocolCode.fromBytes(url.getProtocol()),
             url.getVersion(), url);
-        channel.pipeline().fireUserEventTriggered(ConnectionEventType.CONNECT);
+        if (channel.isActive()) {
+            channel.pipeline().fireUserEventTriggered(ConnectionEventType.CONNECT);
+        } else {
+            channel.pipeline().fireUserEventTriggered(ConnectionEventType.CONNECT_FAILED);
+        }
         return conn;
     }
 
@@ -150,7 +154,11 @@ public abstract class AbstractConnectionFactory implements ConnectionFactory {
         Connection conn = new Connection(channel,
             ProtocolCode.fromBytes(RpcProtocol.PROTOCOL_CODE), RpcProtocolV2.PROTOCOL_VERSION_1,
             new Url(targetIP, targetPort));
-        channel.pipeline().fireUserEventTriggered(ConnectionEventType.CONNECT);
+        if (channel.isActive()) {
+            channel.pipeline().fireUserEventTriggered(ConnectionEventType.CONNECT);
+        } else {
+            channel.pipeline().fireUserEventTriggered(ConnectionEventType.CONNECT_FAILED);
+        }
         return conn;
     }
 
@@ -161,7 +169,11 @@ public abstract class AbstractConnectionFactory implements ConnectionFactory {
         Connection conn = new Connection(channel,
             ProtocolCode.fromBytes(RpcProtocolV2.PROTOCOL_CODE), version, new Url(targetIP,
                 targetPort));
-        channel.pipeline().fireUserEventTriggered(ConnectionEventType.CONNECT);
+        if (channel.isActive()) {
+            channel.pipeline().fireUserEventTriggered(ConnectionEventType.CONNECT);
+        } else {
+            channel.pipeline().fireUserEventTriggered(ConnectionEventType.CONNECT_FAILED);
+        }
         return conn;
     }
 

--- a/src/main/java/com/alipay/remoting/util/FutureTaskUtil.java
+++ b/src/main/java/com/alipay/remoting/util/FutureTaskUtil.java
@@ -46,9 +46,9 @@ public class FutureTaskUtil {
             } catch (ExecutionException e) {
                 logger.error("Future task execute failed!", e);
             } catch (FutureTaskNotRunYetException e) {
-                logger.error("Future task has not run yet!", e);
+                logger.warn("Future task has not run yet!", e);
             } catch (FutureTaskNotCompleted e) {
-                logger.error("Future task has not completed!", e);
+                logger.warn("Future task has not completed!", e);
             }
         }
         return t;

--- a/src/test/java/com/alipay/remoting/rpc/connectionmanage/ConnectionExceptionTest.java
+++ b/src/test/java/com/alipay/remoting/rpc/connectionmanage/ConnectionExceptionTest.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alipay.remoting.rpc.connectionmanage;
+
+import com.alipay.remoting.Connection;
+import com.alipay.remoting.ConnectionEventProcessor;
+import com.alipay.remoting.ConnectionEventType;
+import com.alipay.remoting.exception.RemotingException;
+import com.alipay.remoting.rpc.RpcClient;
+import com.alipay.remoting.rpc.common.BoltServer;
+import com.alipay.remoting.rpc.common.CONNECTEventProcessor;
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * @author chengyi (mark.lx@antfin.com) 2019-06-27 13:49
+ */
+public class ConnectionExceptionTest {
+
+    @Test
+    public void testConnectionException() throws RemotingException, InterruptedException {
+        CONNECTEventProcessor serverConnectProcessor = new CONNECTEventProcessor();
+
+        BoltServer boltServer = new BoltServer(1024);
+        boltServer.addConnectionEventProcessor(ConnectionEventType.CONNECT, serverConnectProcessor);
+        boltServer.start();
+
+        final String[] closedUrl = new String[1];
+        RpcClient client = new RpcClient();
+        client.enableReconnectSwitch();
+        client.addConnectionEventProcessor(ConnectionEventType.CLOSE,
+            new ConnectionEventProcessor() {
+                @Override
+                public void onEvent(String remoteAddr, Connection conn) {
+                    closedUrl[0] = remoteAddr;
+                }
+            });
+        client.init();
+
+        Connection connection = client.getConnection("127.0.0.1:1024", 1000);
+        Thread.sleep(10);
+        Assert.assertEquals(1, serverConnectProcessor.getConnectTimes());
+
+        connection.getChannel().close();
+
+        Thread.sleep(100);
+        Assert.assertTrue("127.0.0.1:1024".equals(closedUrl[0]));
+
+        // connection has been created by ReconnectManager
+        Thread.sleep(1000 * 2);
+        Assert.assertEquals(2, serverConnectProcessor.getConnectTimes());
+        connection = client.getConnection("127.0.0.1:1024", 1000);
+        Assert.assertTrue(connection.isFine());
+        Assert.assertEquals(2, serverConnectProcessor.getConnectTimes());
+
+        boltServer.stop();
+    }
+
+}


### PR DESCRIPTION
1. upgrade version to 1.5.6
2. fix NPE in channelInactive
3. handling reconnection situation with no connection binding with channel
4. du not scan connection pool associated with task that has not been don
5. add CONNECT_FAILED event type and print user event log