### PR TITLE
support user processor with life cycle interface fix #123

### DIFF
--- a/src/main/java/com/alipay/remoting/rpc/RpcClient.java
+++ b/src/main/java/com/alipay/remoting/rpc/RpcClient.java
@@ -347,6 +347,10 @@ public class RpcClient extends AbstractBoltClient {
     @Override
     public void registerUserProcessor(UserProcessor<?> processor) {
         UserProcessorRegisterHelper.registerUserProcessor(processor, this.userProcessors);
+        // startup the processor if it registered after component startup
+        if (isStarted()) {
+            processor.startup();
+        }
     }
 
     @Override

--- a/src/main/java/com/alipay/remoting/rpc/RpcClient.java
+++ b/src/main/java/com/alipay/remoting/rpc/RpcClient.java
@@ -111,7 +111,9 @@ public class RpcClient extends AbstractBoltClient {
             connectionMonitor.shutdown();
         }
         for (UserProcessor<?> userProcessor : userProcessors.values()) {
-            userProcessor.shutdown();
+            if (userProcessor.isStarted()) {
+                userProcessor.shutdown();
+            }
         }
     }
 
@@ -120,7 +122,9 @@ public class RpcClient extends AbstractBoltClient {
         super.startup();
 
         for (UserProcessor<?> userProcessor : userProcessors.values()) {
-            userProcessor.startup();
+            if (!userProcessor.isStarted()) {
+                userProcessor.startup();
+            }
         }
 
         if (this.addressParser == null) {
@@ -348,7 +352,7 @@ public class RpcClient extends AbstractBoltClient {
     public void registerUserProcessor(UserProcessor<?> processor) {
         UserProcessorRegisterHelper.registerUserProcessor(processor, this.userProcessors);
         // startup the processor if it registered after component startup
-        if (isStarted()) {
+        if (isStarted() && !processor.isStarted()) {
             processor.startup();
         }
     }

--- a/src/main/java/com/alipay/remoting/rpc/RpcClient.java
+++ b/src/main/java/com/alipay/remoting/rpc/RpcClient.java
@@ -51,7 +51,7 @@ import com.alipay.remoting.rpc.protocol.UserProcessorRegisterHelper;
 
 /**
  * Client for Rpc.
- * 
+ *
  * @author jiangping
  * @version $Id: RpcClient.java, v 0.1 2015-9-23 PM4:03:28 tao Exp $
  */
@@ -110,11 +110,18 @@ public class RpcClient extends AbstractBoltClient {
         if (connectionMonitor != null) {
             connectionMonitor.shutdown();
         }
+        for (UserProcessor<?> userProcessor : userProcessors.values()) {
+            userProcessor.shutdown();
+        }
     }
 
     @Override
     public void startup() throws LifeCycleException {
         super.startup();
+
+        for (UserProcessor<?> userProcessor : userProcessors.values()) {
+            userProcessor.startup();
+        }
 
         if (this.addressParser == null) {
             this.addressParser = new RpcAddressParser();
@@ -395,7 +402,7 @@ public class RpcClient extends AbstractBoltClient {
 
     /**
      * Close all connections of a address
-     * 
+     *
      * @param addr
      */
     public void closeConnection(String addr) {

--- a/src/main/java/com/alipay/remoting/rpc/RpcServer.java
+++ b/src/main/java/com/alipay/remoting/rpc/RpcServer.java
@@ -384,6 +384,10 @@ public class RpcServer extends AbstractRemotingServer {
 
     @Override
     protected boolean doStart() throws InterruptedException {
+        for (UserProcessor<?> userProcessor : userProcessors.values()) {
+            userProcessor.startup();
+        }
+
         this.channelFuture = this.bootstrap.bind(new InetSocketAddress(ip(), port())).sync();
         if (port() == 0 && channelFuture.isSuccess()) {
             InetSocketAddress localAddress = (InetSocketAddress) channelFuture.channel()
@@ -413,6 +417,9 @@ public class RpcServer extends AbstractRemotingServer {
             && null != this.connectionManager) {
             this.connectionManager.shutdown();
             logger.warn("Close all connections from server side!");
+        }
+        for (UserProcessor<?> userProcessor : userProcessors.values()) {
+            userProcessor.shutdown();
         }
         logger.warn("Rpc Server stopped!");
         return true;

--- a/src/main/java/com/alipay/remoting/rpc/RpcServer.java
+++ b/src/main/java/com/alipay/remoting/rpc/RpcServer.java
@@ -385,7 +385,9 @@ public class RpcServer extends AbstractRemotingServer {
     @Override
     protected boolean doStart() throws InterruptedException {
         for (UserProcessor<?> userProcessor : userProcessors.values()) {
-            userProcessor.startup();
+            if (!userProcessor.isStarted()) {
+                userProcessor.startup();
+            }
         }
 
         this.channelFuture = this.bootstrap.bind(new InetSocketAddress(ip(), port())).sync();
@@ -419,7 +421,9 @@ public class RpcServer extends AbstractRemotingServer {
             logger.warn("Close all connections from server side!");
         }
         for (UserProcessor<?> userProcessor : userProcessors.values()) {
-            userProcessor.shutdown();
+            if (userProcessor.isStarted()) {
+                userProcessor.shutdown();
+            }
         }
         logger.warn("Rpc Server stopped!");
         return true;
@@ -471,7 +475,7 @@ public class RpcServer extends AbstractRemotingServer {
     public void registerUserProcessor(UserProcessor<?> processor) {
         UserProcessorRegisterHelper.registerUserProcessor(processor, this.userProcessors);
         // startup the processor if it registered after component startup
-        if (isStarted()) {
+        if (isStarted() && !processor.isStarted()) {
             processor.startup();
         }
     }

--- a/src/main/java/com/alipay/remoting/rpc/RpcServer.java
+++ b/src/main/java/com/alipay/remoting/rpc/RpcServer.java
@@ -470,6 +470,10 @@ public class RpcServer extends AbstractRemotingServer {
     @Override
     public void registerUserProcessor(UserProcessor<?> processor) {
         UserProcessorRegisterHelper.registerUserProcessor(processor, this.userProcessors);
+        // startup the processor if it registered after component startup
+        if (isStarted()) {
+            processor.startup();
+        }
     }
 
     /**

--- a/src/main/java/com/alipay/remoting/rpc/protocol/AbstractUserProcessor.java
+++ b/src/main/java/com/alipay/remoting/rpc/protocol/AbstractUserProcessor.java
@@ -18,24 +18,26 @@ package com.alipay.remoting.rpc.protocol;
 
 import java.util.concurrent.Executor;
 
+import com.alipay.remoting.AbstractLifeCycle;
 import com.alipay.remoting.BizContext;
 import com.alipay.remoting.DefaultBizContext;
 import com.alipay.remoting.RemotingContext;
 
 /**
  * Implements common function and provide default value.
- * 
+ *
  * @author xiaomin.cxm
  * @version $Id: AbstractUserProcessor.java, v 0.1 May 19, 2016 3:38:22 PM xiaomin.cxm Exp $
  */
-public abstract class AbstractUserProcessor<T> implements UserProcessor<T> {
+public abstract class AbstractUserProcessor<T> extends AbstractLifeCycle implements
+                                                                        UserProcessor<T> {
 
     /** executor selector, default null unless provide one using its setter method */
     protected ExecutorSelector executorSelector;
 
     /**
      * Provide a default - {@link DefaultBizContext} implementation of {@link BizContext}.
-     * 
+     *
      * @see com.alipay.remoting.rpc.protocol.UserProcessor#preHandleRequest(com.alipay.remoting.RemotingContext, java.lang.Object)
      */
     @Override
@@ -72,7 +74,7 @@ public abstract class AbstractUserProcessor<T> implements UserProcessor<T> {
     /**
      * By default, return false, means not deserialize and process biz logic in io thread
      *
-     * @see UserProcessor#processInIOThread() 
+     * @see UserProcessor#processInIOThread()
      */
     @Override
     public boolean processInIOThread() {

--- a/src/main/java/com/alipay/remoting/rpc/protocol/UserProcessor.java
+++ b/src/main/java/com/alipay/remoting/rpc/protocol/UserProcessor.java
@@ -20,15 +20,16 @@ import java.util.concurrent.Executor;
 
 import com.alipay.remoting.AsyncContext;
 import com.alipay.remoting.BizContext;
+import com.alipay.remoting.LifeCycle;
 import com.alipay.remoting.RemotingContext;
 
 /**
  * Defined all functions for biz to process user defined request.
- * 
+ *
  * @author xiaomin.cxm
  * @version $Id: UserProcessor.java, v 0.1 May 19, 2016 2:16:13 PM xiaomin.cxm Exp $
  */
-public interface UserProcessor<T> {
+public interface UserProcessor<T> extends LifeCycle {
 
     /**
      * Pre handle request, to avoid expose {@link RemotingContext} directly to biz handle request logic.


### PR DESCRIPTION
#123 
support user processor with life cycle.
```java
public class SimpleUserProcessor implements UserProcessor {
    ...
         public void startup() {
         // do startup
         } 

         public void shutdown() {
        // do shutdown
         } 
}

```
Both RpcClient and RpcServer will startup all the userProcessor when startup and shutdown all the userProcessor when shutdown.

```java
public void startup() throws LifeCycleException {
        super.startup();

        for (UserProcessor<?> userProcessor : userProcessors.values()) {
            userProcessor.startup();
        }
        // startup other components
        ... 
    }
```

```java
public void shutdown() {
        super.shutdown();
     
        // shutdown other components
        ... 

        for (UserProcessor<?> userProcessor : userProcessors.values()) {
            userProcessor.shutdown();
        }
}
```


