### PR TITLE
Add rejection-processable InvokeCallback . fix #178

### DIFF
--- a/src/main/java/com/alipay/remoting/RejectedExecutionPolicy.java
+++ b/src/main/java/com/alipay/remoting/RejectedExecutionPolicy.java
@@ -16,35 +16,17 @@
  */
 package com.alipay.remoting;
 
-import java.util.concurrent.Executor;
-
 /**
- * Invoke callback.
+ * RejectedExecutionPolicy determines how to deal with this situation that user executor rejected the {@link com.alipay.remoting.rpc.RpcInvokeCallbackListener.CallbackTask}.
  *
- * @author jiangping
- * @version $Id: InvokeCallback.java, v 0.1 2015-9-30 AM10:24:26 tao Exp $
+ * @author muyun
+ * @version $Id: RejectedExecutionPolicy.java, v 0.1 2019年12月05日 7:38 PM muyun Exp $
  */
-public interface InvokeCallback {
-
-    /**
-     * Response received.
-     *
-     * @param result
-     */
-    void onResponse(final Object result);
-
-    /**
-     * Exception caught.
-     *
-     * @param e
-     */
-    void onException(final Throwable e);
-
-    /**
-     * User defined executor.
-     *
-     * @return
-     */
-    Executor getExecutor();
-
+public enum RejectedExecutionPolicy {
+    /* discard the callback task */
+    DISCARD,
+    /* caller runs the callback in IO-thread */
+    CALLER_RUNS,
+    /* caller handle the task with exception strategy user provided */
+    CALLER_HANDLE_EXCEPTION
 }

--- a/src/main/java/com/alipay/remoting/RejectionProcessableInvokeCallback.java
+++ b/src/main/java/com/alipay/remoting/RejectionProcessableInvokeCallback.java
@@ -16,35 +16,19 @@
  */
 package com.alipay.remoting;
 
-import java.util.concurrent.Executor;
-
 /**
- * Invoke callback.
+ * InvokeCallback which support {@link RejectedExecutionPolicy} is able to process the task-rejected situation.
  *
- * @author jiangping
- * @version $Id: InvokeCallback.java, v 0.1 2015-9-30 AM10:24:26 tao Exp $
+ * @author muyun
+ * @version $Id: RejectionProcessableInvokeCallback.java, v 0.1 2019年12月05日 9:16 PM muyun Exp $
  */
-public interface InvokeCallback {
+public interface RejectionProcessableInvokeCallback extends InvokeCallback {
 
     /**
-     * Response received.
-     *
-     * @param result
+     * when user executor rejected the {@link com.alipay.remoting.rpc.RpcInvokeCallbackListener.CallbackTask},
+     * bolt will handle the rejected task according to this {@link RejectedExecutionPolicy}
+     * @return rejectedExecution Policy
+     * @see com.alipay.remoting.rpc.RpcInvokeCallbackListener#onResponse(InvokeFuture)
      */
-    void onResponse(final Object result);
-
-    /**
-     * Exception caught.
-     *
-     * @param e
-     */
-    void onException(final Throwable e);
-
-    /**
-     * User defined executor.
-     *
-     * @return
-     */
-    Executor getExecutor();
-
+    RejectedExecutionPolicy rejectedExecutionPolicy();
 }

--- a/src/main/java/com/alipay/remoting/rpc/RpcInvokeCallbackListener.java
+++ b/src/main/java/com/alipay/remoting/rpc/RpcInvokeCallbackListener.java
@@ -18,12 +18,9 @@ package com.alipay.remoting.rpc;
 
 import java.util.concurrent.RejectedExecutionException;
 
+import com.alipay.remoting.*;
 import org.slf4j.Logger;
 
-import com.alipay.remoting.InvokeCallback;
-import com.alipay.remoting.InvokeCallbackListener;
-import com.alipay.remoting.InvokeFuture;
-import com.alipay.remoting.ResponseStatus;
 import com.alipay.remoting.exception.CodecException;
 import com.alipay.remoting.exception.ConnectionClosedException;
 import com.alipay.remoting.log.BoltLoggerFactory;
@@ -35,7 +32,7 @@ import com.alipay.remoting.rpc.protocol.RpcResponseCommand;
 
 /**
  * Listener which listens the Rpc invoke result, and then invokes the call back.
- * 
+ *
  * @author jiangping
  * @version $Id: RpcInvokeCallbackListener.java, v 0.1 2015-9-30 AM10:36:34 tao Exp $
  */
@@ -53,7 +50,7 @@ public class RpcInvokeCallbackListener implements InvokeCallbackListener {
         this.address = address;
     }
 
-    /** 
+    /**
      * @see com.alipay.remoting.InvokeCallbackListener#onResponse(com.alipay.remoting.InvokeFuture)
      */
     @Override
@@ -66,7 +63,23 @@ public class RpcInvokeCallbackListener implements InvokeCallbackListener {
                 try {
                     callback.getExecutor().execute(task);
                 } catch (RejectedExecutionException e) {
-                    logger.warn("Callback thread pool busy.");
+                    if (callback instanceof RejectionProcessableInvokeCallback) {
+                        switch (((RejectionProcessableInvokeCallback) callback)
+                            .rejectedExecutionPolicy()) {
+                            case CALLER_RUNS:
+                                task.run();
+                                break;
+                            case CALLER_HANDLE_EXCEPTION:
+                                callback.onException(e);
+                                break;
+                            case DISCARD:
+                            default:
+                                logger.warn("Callback thread pool busy. discard the callback");
+                                break;
+                        }
+                    } else {
+                        logger.warn("Callback thread pool busy.");
+                    }
                 }
             } else {
                 task.run();
@@ -80,14 +93,14 @@ public class RpcInvokeCallbackListener implements InvokeCallbackListener {
         String       remoteAddress;
 
         /**
-         * 
+         *
          */
         public CallbackTask(String remoteAddress, InvokeFuture future) {
             this.remoteAddress = remoteAddress;
             this.future = future;
         }
 
-        /** 
+        /**
          * @see java.lang.Runnable#run()
          */
         @Override
@@ -191,7 +204,7 @@ public class RpcInvokeCallbackListener implements InvokeCallbackListener {
         } // end of run
     }
 
-    /** 
+    /**
      * @see com.alipay.remoting.InvokeCallbackListener#getRemoteAddress()
      */
     @Override

--- a/src/test/java/com/alipay/remoting/rpc/callback/RejectionProcessableInvokeCallbackTest.java
+++ b/src/test/java/com/alipay/remoting/rpc/callback/RejectionProcessableInvokeCallbackTest.java
@@ -1,0 +1,192 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alipay.remoting.rpc.callback;
+
+import com.alipay.remoting.*;
+import com.alipay.remoting.rpc.RpcClient;
+import com.alipay.remoting.rpc.common.*;
+import com.alipay.remoting.util.ThreadTestUtils;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.Executor;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ *
+ * @author muyun
+ * @version $Id: RejectionProcessableInvokeCallbackTest.java, v 0.1 2019年12月05日 9:29 PM muyun Exp $
+ */
+public class RejectionProcessableInvokeCallbackTest {
+    private BoltServer                server;
+    private RpcClient                 client;
+
+    private int                       port                      = PortScan.select();
+    private String                    ip                        = "127.0.0.1";
+    private String                    addr                      = "127.0.0.1:" + port;
+
+    private SimpleServerUserProcessor serverUserProcessor       = new SimpleServerUserProcessor();
+    private SimpleClientUserProcessor clientUserProcessor       = new SimpleClientUserProcessor();
+    private CONNECTEventProcessor     clientConnectProcessor    = new CONNECTEventProcessor();
+    private CONNECTEventProcessor     serverConnectProcessor    = new CONNECTEventProcessor();
+    private DISCONNECTEventProcessor  clientDisConnectProcessor = new DISCONNECTEventProcessor();
+    private DISCONNECTEventProcessor  serverDisConnectProcessor = new DISCONNECTEventProcessor();
+
+    private ThreadPoolExecutor        executor;
+    private InvokeCallback            callback;
+
+    @Before
+    public void setUp() {
+        server = new BoltServer(port, true);
+        server.start();
+        server.addConnectionEventProcessor(ConnectionEventType.CONNECT, serverConnectProcessor);
+        server.addConnectionEventProcessor(ConnectionEventType.CLOSE, serverDisConnectProcessor);
+        server.registerUserProcessor(serverUserProcessor);
+
+        client = new RpcClient();
+        client.addConnectionEventProcessor(ConnectionEventType.CONNECT, clientConnectProcessor);
+        client.addConnectionEventProcessor(ConnectionEventType.CLOSE, clientDisConnectProcessor);
+        client.registerUserProcessor(clientUserProcessor);
+        client.startup();
+
+        executor = new ThreadPoolExecutor(1, 1, 60, TimeUnit.SECONDS,
+            new ArrayBlockingQueue<Runnable>(2), new NamedThreadFactory(
+                "test-rejection-processable"));
+    }
+
+    @After
+    public void tearDown() {
+        server.stop();
+        executor.shutdown();
+    }
+
+    @Test
+    public void testCallerRunsPolicy() {
+        RequestBody req = new RequestBody(1, "hello world sync");
+        final AtomicInteger count = new AtomicInteger(0);
+        callback = new RejectionProcessableInvokeCallback() {
+            @Override
+            public RejectedExecutionPolicy rejectedExecutionPolicy() {
+                return RejectedExecutionPolicy.CALLER_RUNS;
+            }
+
+            @Override
+            public void onResponse(Object result) {
+                count.incrementAndGet();
+            }
+
+            @Override
+            public void onException(Throwable e) {
+                Assert.fail("should not reach here");
+            }
+
+            @Override
+            public Executor getExecutor() {
+                return executor;
+            }
+        };
+        try {
+            for (int i = 0; i < 5; i++) {
+                client.invokeWithCallback(addr, req, callback, 3000);
+            }
+            ThreadTestUtils.sleep(1000);
+            Assert.assertEquals(5, count.get());
+        } catch (Exception e) {
+            e.printStackTrace();
+            Assert.fail();
+        }
+    }
+
+    @Test
+    public void testDiscardPolicy() {
+        RequestBody req = new RequestBody(1, "hello world sync");
+        final AtomicInteger count = new AtomicInteger(0);
+        callback = new RejectionProcessableInvokeCallback() {
+            @Override
+            public RejectedExecutionPolicy rejectedExecutionPolicy() {
+                return RejectedExecutionPolicy.DISCARD;
+            }
+
+            @Override
+            public void onResponse(Object result) {
+                count.incrementAndGet();
+            }
+
+            @Override
+            public void onException(Throwable e) {
+                Assert.fail("should not reach here");
+            }
+
+            @Override
+            public Executor getExecutor() {
+                return executor;
+            }
+        };
+        try {
+            for (int i = 0; i < 5; i++) {
+                client.invokeWithCallback(addr, req, callback, 3000);
+            }
+            ThreadTestUtils.sleep(1000);
+            Assert.assertEquals(3, count.get());
+        } catch (Exception e) {
+            e.printStackTrace();
+            Assert.fail();
+        }
+    }
+
+    @Test
+    public void testCallerHandleExceptionPolicy() {
+        RequestBody req = new RequestBody(1, "hello world sync");
+        final AtomicInteger errCount = new AtomicInteger(0);
+        callback = new RejectionProcessableInvokeCallback() {
+            @Override
+            public RejectedExecutionPolicy rejectedExecutionPolicy() {
+                return RejectedExecutionPolicy.CALLER_HANDLE_EXCEPTION;
+            }
+
+            @Override
+            public void onResponse(Object result) {
+            }
+
+            @Override
+            public void onException(Throwable e) {
+                errCount.incrementAndGet();
+            }
+
+            @Override
+            public Executor getExecutor() {
+                return executor;
+            }
+        };
+        try {
+            for (int i = 0; i < 5; i++) {
+                client.invokeWithCallback(addr, req, callback, 3000);
+            }
+            ThreadTestUtils.sleep(1000);
+            Assert.assertEquals(2, errCount.get());
+        } catch (Exception e) {
+            e.printStackTrace();
+            Assert.fail();
+        }
+    }
+
+}


### PR DESCRIPTION
add rejection-processable InvokeCallback to provide flexible options when user executor rejected task.
```java
public interface RejectionProcessableInvokeCallback extends InvokeCallback {

    /**
     * when user executor rejected the {@link com.alipay.remoting.rpc.RpcInvokeCallbackListener.CallbackTask},
     * bolt will handle the rejected task according to this {@link RejectedExecutionPolicy}
     * @return rejectedExecution Policy
     * @see com.alipay.remoting.rpc.RpcInvokeCallbackListener#onResponse(InvokeFuture)
     */
    RejectedExecutionPolicy rejectedExecutionPolicy();
}
```

```java
public enum RejectedExecutionPolicy {
    /* discard the callback task */
    DISCARD,
    /* caller runs the callback in IO-thread */
    CALLER_RUNS,
    /* caller handle the task with exception strategy user provided */
    CALLER_HANDLE_EXCEPTION
}
```

