### PR TITLE
complete tcp related config. see #171

### DIFF
--- a/src/main/java/com/alipay/remoting/config/BoltGenericOption.java
+++ b/src/main/java/com/alipay/remoting/config/BoltGenericOption.java
@@ -36,6 +36,10 @@ public class BoltGenericOption<T> extends BoltOption<T> {
                                                                                               "bolt.tcp.so.keepalive",
                                                                                               true);
 
+    public static final BoltOption<Integer>                  TCP_SO_SNDBUF                = valueOf("bolt.tcp.so.sndbuf");
+
+    public static final BoltOption<Integer>                  TCP_SO_RCVBUF                = valueOf("bolt.tcp.so.rcvbuf");
+
     public static final BoltOption<Integer>                  NETTY_IO_RATIO               = valueOf(
                                                                                               "bolt.netty.io.ratio",
                                                                                               70);

--- a/src/main/java/com/alipay/remoting/config/ConfigManager.java
+++ b/src/main/java/com/alipay/remoting/config/ConfigManager.java
@@ -16,6 +16,8 @@
  */
 package com.alipay.remoting.config;
 
+import static java.lang.System.getProperty;
+
 /**
  * get configs through system properties prior to default value
  *
@@ -38,6 +40,14 @@ public class ConfigManager {
 
     public static boolean tcp_so_keepalive() {
         return getBool(Configs.TCP_SO_KEEPALIVE, Configs.TCP_SO_KEEPALIVE_DEFAULT);
+    }
+
+    public static Integer tcp_so_sndbuf() {
+        return getInteger(Configs.TCP_SO_SNDBUF, null);
+    }
+
+    public static Integer tcp_so_rcvbuf() {
+        return getInteger(Configs.TCP_SO_RCVBUF, null);
     }
 
     public static int netty_io_ratio() {
@@ -154,22 +164,27 @@ public class ConfigManager {
 
     // ~~~ public helper methods to retrieve system property
     public static boolean getBool(final String key, final String defaultValue) {
-        return Boolean.parseBoolean(System.getProperty(key, defaultValue));
+        return Boolean.parseBoolean(getProperty(key, defaultValue));
     }
 
     public static int getInt(final String key, final String defaultValue) {
-        return Integer.parseInt(System.getProperty(key, defaultValue));
+        return Integer.parseInt(getProperty(key, defaultValue));
+    }
+
+    public static Integer getInteger(final String key, final String defaultValue) {
+        String value = System.getProperty(key, null);
+        return value != null ? Integer.parseInt(value) : null;
     }
 
     public static byte getByte(final String key, final String defaultValue) {
-        return Byte.parseByte(System.getProperty(key, defaultValue));
+        return Byte.parseByte(getProperty(key, defaultValue));
     }
 
     public static long getLong(final String key, final String defaultValue) {
-        return Long.parseLong(System.getProperty(key, defaultValue));
+        return Long.parseLong(getProperty(key, defaultValue));
     }
 
     public static String getString(final String key, final String defaultValue) {
-        return System.getProperty(key, defaultValue);
+        return getProperty(key, defaultValue);
     }
 }

--- a/src/main/java/com/alipay/remoting/config/Configs.java
+++ b/src/main/java/com/alipay/remoting/config/Configs.java
@@ -44,6 +44,11 @@ public class Configs {
     public static final String TCP_SO_KEEPALIVE                      = "bolt.tcp.so.keepalive";
     public static final String TCP_SO_KEEPALIVE_DEFAULT              = "true";
 
+    /** TCP SO_SNDBUF option */
+    public static final String TCP_SO_SNDBUF                         = "bolt.tcp.so.sndbuf";
+    /** TCP SO_RCVBUF option */
+    public static final String TCP_SO_RCVBUF                         = "bolt.tcp.so.rcvbuf";
+
     /** Netty ioRatio option*/
     public static final String NETTY_IO_RATIO                        = "bolt.netty.io.ratio";
     public static final String NETTY_IO_RATIO_DEFAULT                = "70";

--- a/src/main/java/com/alipay/remoting/connection/AbstractConnectionFactory.java
+++ b/src/main/java/com/alipay/remoting/connection/AbstractConnectionFactory.java
@@ -23,6 +23,7 @@ import java.security.KeyStore;
 import java.util.concurrent.TimeUnit;
 import javax.net.ssl.SSLEngine;
 import javax.net.ssl.TrustManagerFactory;
+
 import org.slf4j.Logger;
 
 import com.alipay.remoting.Connection;
@@ -104,7 +105,9 @@ public abstract class AbstractConnectionFactory implements ConnectionFactory {
         bootstrap.group(workerGroup).channel(NettyEventLoopUtil.getClientSocketChannelClass())
             .option(ChannelOption.TCP_NODELAY, ConfigManager.tcp_nodelay())
             .option(ChannelOption.SO_REUSEADDR, ConfigManager.tcp_so_reuseaddr())
-            .option(ChannelOption.SO_KEEPALIVE, ConfigManager.tcp_so_keepalive());
+            .option(ChannelOption.SO_KEEPALIVE, ConfigManager.tcp_so_keepalive())
+            .option(ChannelOption.SO_SNDBUF, ConfigManager.tcp_so_sndbuf())
+            .option(ChannelOption.SO_RCVBUF, ConfigManager.tcp_so_rcvbuf());
 
         // init netty write buffer water mark
         initWriteBufferWaterMark();
@@ -152,6 +155,9 @@ public abstract class AbstractConnectionFactory implements ConnectionFactory {
     @Override
     public Connection createConnection(Url url) throws Exception {
         Channel channel = doCreateConnection(url.getIp(), url.getPort(), url.getConnectTimeout());
+        System.out.println(channel.config().getOption(ChannelOption.SO_SNDBUF));
+        System.out.println(channel.config().getOption(ChannelOption.SO_RCVBUF));
+
         Connection conn = new Connection(channel, ProtocolCode.fromBytes(url.getProtocol()),
             url.getVersion(), url);
         if (channel.isActive()) {

--- a/src/main/java/com/alipay/remoting/rpc/RpcServer.java
+++ b/src/main/java/com/alipay/remoting/rpc/RpcServer.java
@@ -27,6 +27,7 @@ import javax.net.ssl.KeyManagerFactory;
 import javax.net.ssl.SSLEngine;
 import com.alipay.remoting.ConnectionSelectStrategy;
 import com.alipay.remoting.DefaultServerConnectionManager;
+import com.alipay.remoting.config.BoltGenericOption;
 import org.slf4j.Logger;
 
 import com.alipay.remoting.AbstractRemotingServer;
@@ -252,13 +253,22 @@ public class RpcServer extends AbstractRemotingServer {
             this.connectionEventHandler.setConnectionEventListener(this.connectionEventListener);
         }
         initRpcRemoting();
+
+        Integer tcpSoSndBuf = option(BoltGenericOption.TCP_SO_SNDBUF);
+        Integer tcpSoRcvBuf = option(BoltGenericOption.TCP_SO_RCVBUF);
+
         this.bootstrap = new ServerBootstrap();
-        this.bootstrap.group(bossGroup, workerGroup)
+        this.bootstrap
+            .group(bossGroup, workerGroup)
             .channel(NettyEventLoopUtil.getServerSocketChannelClass())
             .option(ChannelOption.SO_BACKLOG, ConfigManager.tcp_so_backlog())
             .option(ChannelOption.SO_REUSEADDR, ConfigManager.tcp_so_reuseaddr())
             .childOption(ChannelOption.TCP_NODELAY, ConfigManager.tcp_nodelay())
-            .childOption(ChannelOption.SO_KEEPALIVE, ConfigManager.tcp_so_keepalive());
+            .childOption(ChannelOption.SO_KEEPALIVE, ConfigManager.tcp_so_keepalive())
+            .childOption(ChannelOption.SO_SNDBUF,
+                tcpSoSndBuf != null ? tcpSoSndBuf : ConfigManager.tcp_so_sndbuf())
+            .childOption(ChannelOption.SO_RCVBUF,
+                tcpSoRcvBuf != null ? tcpSoRcvBuf : ConfigManager.tcp_so_rcvbuf());
 
         // set write buffer water mark
         initWriteBufferWaterMark();

--- a/src/test/java/com/alipay/remoting/inner/utiltest/ConfigManagerTest.java
+++ b/src/test/java/com/alipay/remoting/inner/utiltest/ConfigManagerTest.java
@@ -28,7 +28,7 @@ import com.alipay.remoting.config.Configs;
 
 /**
  * test ConfigManager get config
- * 
+ *
  * @author tsui
  * @version $Id: ConfigManagerTest.java, v 0.1 2017-08-03 21:51 tsui Exp $
  */


### PR DESCRIPTION
fix #171 
Provides custom methods to set value of SO_SND_BUF and SO_RCV_BUF.

**_usage_**:
- first one
```java
        System.setProperty(Configs.TCP_SO_SNDBUF, "8912");
        System.setProperty(Configs.TCP_SO_RCVBUF, "8912");
        RpcServer server = new RpcServer(8099);
        server.startup();
```
- second one
```java
        RpcServer server = new RpcServer(8099);
        server.option(BoltGenericOption.TCP_SO_SNDBUF, 8912);
        server.option(BoltGenericOption.TCP_SO_RCVBUF, 8912);
        server.startup();
```

> The second usage has higher priority than the first usage 