### PR TITLE
Upgrade jdk version to 1.8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -67,7 +67,7 @@
         <cobertura.maven.plugin>2.6</cobertura.maven.plugin>
         <coveralls.maven.plugin>3.2.1</coveralls.maven.plugin>
         <hessian.version>3.3.6</hessian.version>
-        <java.version>1.6</java.version>
+        <java.version>1.8</java.version>
         <license.maven.plugin>3.0</license.maven.plugin>
         <maven.assembly.plugin>3.0.0</maven.assembly.plugin>
         <maven.compiler.plugin>3.5.1</maven.compiler.plugin>

--- a/src/test/java/com/alipay/remoting/config/DefaultConfigContainerTest.java
+++ b/src/test/java/com/alipay/remoting/config/DefaultConfigContainerTest.java
@@ -38,7 +38,7 @@ public class DefaultConfigContainerTest {
         configContainer.set(ConfigType.CLIENT_SIDE, ConfigItem.NETTY_BUFFER_LOW_WATER_MARK,
             expected_int);
         Assert.assertEquals(expected_int,
-            configContainer.get(ConfigType.CLIENT_SIDE, ConfigItem.NETTY_BUFFER_LOW_WATER_MARK));
+                (int)configContainer.get(ConfigType.CLIENT_SIDE, ConfigItem.NETTY_BUFFER_LOW_WATER_MARK));
         Assert.assertNull(configContainer.get(ConfigType.CLIENT_SIDE,
             ConfigItem.NETTY_BUFFER_HIGH_WATER_MARK));
         Assert.assertNull(configContainer.get(ConfigType.SERVER_SIDE,
@@ -77,13 +77,13 @@ public class DefaultConfigContainerTest {
         configContainer.set(ConfigType.CLIENT_SIDE, ConfigItem.NETTY_BUFFER_LOW_WATER_MARK,
             expected_int_overwrite);
         Assert.assertEquals(expected_int_overwrite,
-            configContainer.get(ConfigType.CLIENT_SIDE, ConfigItem.NETTY_BUFFER_LOW_WATER_MARK));
+                (int)configContainer.get(ConfigType.CLIENT_SIDE, ConfigItem.NETTY_BUFFER_LOW_WATER_MARK));
         Assert.assertEquals(expected_int,
-            configContainer.get(ConfigType.CLIENT_SIDE, ConfigItem.NETTY_BUFFER_HIGH_WATER_MARK));
+                (int)configContainer.get(ConfigType.CLIENT_SIDE, ConfigItem.NETTY_BUFFER_HIGH_WATER_MARK));
         Assert.assertEquals(expected_int,
-            configContainer.get(ConfigType.SERVER_SIDE, ConfigItem.NETTY_BUFFER_LOW_WATER_MARK));
+                (int)configContainer.get(ConfigType.SERVER_SIDE, ConfigItem.NETTY_BUFFER_LOW_WATER_MARK));
         Assert.assertEquals(expected_int,
-            configContainer.get(ConfigType.SERVER_SIDE, ConfigItem.NETTY_BUFFER_HIGH_WATER_MARK));
+                (int)configContainer.get(ConfigType.SERVER_SIDE, ConfigItem.NETTY_BUFFER_HIGH_WATER_MARK));
     }
 
     @Test


### PR DESCRIPTION
Assert.assertEquals()，升级1.8后会在编译期进行类型校验。