### PR TITLE
fix(sec): upgrade io.netty:netty-all to 4.1.44.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -81,7 +81,7 @@
         <maven.source.plugin>3.0.0</maven.source.plugin>
         <maven.staging.plugin>1.6.7</maven.staging.plugin>
         <maven.surefire.plugin>2.18.1</maven.surefire.plugin>
-        <netty.version>4.1.42.Final</netty.version>
+        <netty.version>4.1.44.Final</netty.version>
 
         <project.encoding>UTF-8</project.encoding>
         <slf4j.version>1.7.21</slf4j.version>


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in io.netty:netty-all 4.1.42.Final
- [CVE-2020-7238](https://www.oscs1024.com/hd/CVE-2020-7238)


### What did I do？
Upgrade io.netty:netty-all from 4.1.42.Final to 4.1.44.Final for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS