### PR TITLE
[ISSUE #317] async context support send exception, make the async processor keep t…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.alipay.sofa</groupId>
     <artifactId>bolt</artifactId>
-    <version>1.6.5</version>
+    <version>1.6.6</version>
     <packaging>jar</packaging>
 
     <name>${project.groupId}:${project.artifactId}</name>
@@ -68,7 +68,7 @@
         <coveralls.maven.plugin>3.2.1</coveralls.maven.plugin>
         <disruptor.verion>3.4.4</disruptor.verion>
         <hessian.version>3.3.6</hessian.version>
-        <java.version>1.6</java.version>
+        <java.version>1.8</java.version>
         <junit.version>4.13.1</junit.version>
         <license.maven.plugin>3.0</license.maven.plugin>
         <log4j.version>2.17.1</log4j.version>

--- a/src/main/java/com/alipay/remoting/AsyncContext.java
+++ b/src/main/java/com/alipay/remoting/AsyncContext.java
@@ -29,4 +29,10 @@ public interface AsyncContext {
      * @param responseObject response object
      */
     void sendResponse(Object responseObject);
+
+    /**
+     * send exception back
+     * @param ex response exception
+     */
+    void sendException(Throwable ex);
 }

--- a/src/main/java/com/alipay/remoting/AsyncContext.java
+++ b/src/main/java/com/alipay/remoting/AsyncContext.java
@@ -34,5 +34,7 @@ public interface AsyncContext {
      * send exception back
      * @param ex response exception
      */
-    void sendException(Throwable ex);
+    default void sendException(Throwable ex) {
+        throw new UnsupportedOperationException("default not support sendException!");
+    }
 }

--- a/src/main/java/com/alipay/remoting/rpc/protocol/RpcAsyncContext.java
+++ b/src/main/java/com/alipay/remoting/rpc/protocol/RpcAsyncContext.java
@@ -73,8 +73,11 @@ public class RpcAsyncContext implements AsyncContext {
     @Override
     public void sendException(Throwable ex) {
         if (isResponseSentAlready.compareAndSet(false, true)) {
-            processor.sendResponseIfNecessary(this.ctx, cmd.getType(), processor.getCommandFactory()
-                    .createExceptionResponse(this.cmd.getId(), ResponseStatus.SERVER_EXCEPTION, ex));
+            processor.sendResponseIfNecessary(
+                this.ctx,
+                cmd.getType(),
+                processor.getCommandFactory().createExceptionResponse(this.cmd.getId(),
+                    ResponseStatus.SERVER_EXCEPTION, ex));
         } else {
             throw new IllegalStateException("Should not send rpc response repeatedly!");
         }

--- a/src/main/java/com/alipay/remoting/rpc/protocol/RpcAsyncContext.java
+++ b/src/main/java/com/alipay/remoting/rpc/protocol/RpcAsyncContext.java
@@ -20,10 +20,11 @@ import java.util.concurrent.atomic.AtomicBoolean;
 
 import com.alipay.remoting.AsyncContext;
 import com.alipay.remoting.RemotingContext;
+import com.alipay.remoting.ResponseStatus;
 
 /**
  * Async biz context of Rpc.
- * 
+ *
  * @author xiaomin.cxm
  * @version $Id: RpcAsyncContext.java, v 0.1 May 16, 2016 8:23:07 PM xiaomin.cxm Exp $
  */
@@ -61,6 +62,19 @@ public class RpcAsyncContext implements AsyncContext {
         if (isResponseSentAlready.compareAndSet(false, true)) {
             processor.sendResponseIfNecessary(this.ctx, cmd.getType(), processor
                 .getCommandFactory().createResponse(responseObject, this.cmd));
+        } else {
+            throw new IllegalStateException("Should not send rpc response repeatedly!");
+        }
+    }
+
+    /**
+     * @see com.alipay.remoting.AsyncContext#sendException(java.lang.Throwable)
+     */
+    @Override
+    public void sendException(Throwable ex) {
+        if (isResponseSentAlready.compareAndSet(false, true)) {
+            processor.sendResponseIfNecessary(this.ctx, cmd.getType(), processor.getCommandFactory()
+                    .createExceptionResponse(this.cmd.getId(), ResponseStatus.SERVER_EXCEPTION, ex));
         } else {
             throw new IllegalStateException("Should not send rpc response repeatedly!");
         }

--- a/src/test/java/com/alipay/remoting/rpc/common/AsyncServerUserProcessor.java
+++ b/src/test/java/com/alipay/remoting/rpc/common/AsyncServerUserProcessor.java
@@ -53,6 +53,9 @@ public class AsyncServerUserProcessor extends AsyncUserProcessor<RequestBody> {
     /** whether exception */
     private boolean             isException;
 
+    /** whether using write_exception */
+    private boolean             sendExceptionSwitch;
+
     /** whether null */
     private boolean             isNull;
 
@@ -74,6 +77,7 @@ public class AsyncServerUserProcessor extends AsyncUserProcessor<RequestBody> {
     public AsyncServerUserProcessor() {
         this.delaySwitch = false;
         this.isException = false;
+        this.sendExceptionSwitch = false;
         this.delayMs = 0;
         this.executor = new ThreadPoolExecutor(1, 3, 60, TimeUnit.SECONDS,
             new ArrayBlockingQueue<Runnable>(4), new NamedThreadFactory("Request-process-pool"));
@@ -84,6 +88,14 @@ public class AsyncServerUserProcessor extends AsyncUserProcessor<RequestBody> {
 
     public AsyncServerUserProcessor(boolean isException, boolean isNull) {
         this();
+        this.isException = isException;
+        this.sendExceptionSwitch = false;
+        this.isNull = isNull;
+    }
+
+    public AsyncServerUserProcessor(boolean sendException, boolean isException, boolean isNull) {
+        this();
+        this.sendExceptionSwitch = sendException;
         this.isException = isException;
         this.isNull = isNull;
     }
@@ -129,7 +141,11 @@ public class AsyncServerUserProcessor extends AsyncUserProcessor<RequestBody> {
             Assert.assertEquals(RequestBody.class, request.getClass());
             processTimes(request);
             if (isException) {
-                this.asyncCtx.sendResponse(new IllegalArgumentException("Exception test"));
+                if (sendExceptionSwitch) {
+                    this.asyncCtx.sendException(new IllegalArgumentException("Exception test"));
+                } else {
+                    this.asyncCtx.sendResponse(new IllegalArgumentException("Exception test"));
+                }
             } else if (isNull) {
                 this.asyncCtx.sendResponse(null);
             } else {

--- a/src/test/java/com/alipay/remoting/rpc/exception/BasicUsage_AsyncProcessor_ExceptionV2_Test.java
+++ b/src/test/java/com/alipay/remoting/rpc/exception/BasicUsage_AsyncProcessor_ExceptionV2_Test.java
@@ -1,0 +1,206 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alipay.remoting.rpc.exception;
+
+import com.alipay.remoting.ConnectionEventType;
+import com.alipay.remoting.InvokeCallback;
+import com.alipay.remoting.exception.RemotingException;
+import com.alipay.remoting.rpc.RpcClient;
+import com.alipay.remoting.rpc.common.*;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Executor;
+import java.util.concurrent.Executors;
+
+/**
+ * test async send back exception
+ *
+ * @author welkin.xu
+ */
+public class BasicUsage_AsyncProcessor_ExceptionV2_Test {
+    static Logger logger = LoggerFactory.getLogger(BasicUsage_AsyncProcessor_ExceptionV2_Test.class);
+
+    BoltServer server;
+    RpcClient  client;
+
+    int    port = PortScan.select();
+    String addr = "127.0.0.1:" + port;
+
+    int invokeTimes = 5;
+
+    AsyncServerUserProcessor serverUserProcessor       = new AsyncServerUserProcessor(true, true, false);
+    AsyncClientUserProcessor clientUserProcessor       = new AsyncClientUserProcessor( true, false);
+    CONNECTEventProcessor    clientConnectProcessor    = new CONNECTEventProcessor();
+    CONNECTEventProcessor    serverConnectProcessor    = new CONNECTEventProcessor();
+    DISCONNECTEventProcessor clientDisConnectProcessor = new DISCONNECTEventProcessor();
+    DISCONNECTEventProcessor serverDisConnectProcessor = new DISCONNECTEventProcessor();
+
+    @Before
+    public void init() {
+        server = new BoltServer(port, true);
+        server.start();
+        server.addConnectionEventProcessor(ConnectionEventType.CONNECT, serverConnectProcessor);
+        server.addConnectionEventProcessor(ConnectionEventType.CLOSE, serverDisConnectProcessor);
+        server.registerUserProcessor(serverUserProcessor);
+
+        client = new RpcClient();
+        client.addConnectionEventProcessor(ConnectionEventType.CONNECT, clientConnectProcessor);
+        client.addConnectionEventProcessor(ConnectionEventType.CLOSE, clientDisConnectProcessor);
+        client.registerUserProcessor(clientUserProcessor);
+        client.startup();
+    }
+
+    @After
+    public void stop() {
+        try {
+            server.stop();
+            Thread.sleep(100);
+        } catch (InterruptedException e) {
+            logger.error("Stop server failed!", e);
+        }
+    }
+
+    @Test
+    public void testOneway() throws InterruptedException {
+        RequestBody req = new RequestBody(2, "hello world oneway");
+        for (int i = 0; i < invokeTimes; i++) {
+            try {
+                client.oneway(addr, req);
+                Thread.sleep(100);
+            } catch (RemotingException e) {
+                String errMsg = "RemotingException caught in oneway!";
+                logger.error(errMsg, e);
+                Assert.fail(errMsg);
+            }
+        }
+
+        Assert.assertTrue(serverConnectProcessor.isConnected());
+        Assert.assertEquals(1, serverConnectProcessor.getConnectTimes());
+        Assert.assertEquals(invokeTimes, serverUserProcessor.getInvokeTimes());
+    }
+
+    @Test
+    public void testSync() throws InterruptedException {
+        RequestBody req = new RequestBody(1, "hello world sync");
+        for (int i = 0; i < invokeTimes; i++) {
+            try {
+                client.invokeSync(addr, req, 3000);
+                Assert.fail("Should not reach here!");
+            } catch (InvokeServerException e) {
+                Assert.assertTrue(true);
+            } catch (RemotingException e) {
+                String errMsg = "RemotingException caught in sync!";
+                logger.error(errMsg, e);
+                Assert.fail("Should not reach here!");
+            } catch (InterruptedException e) {
+                String errMsg = "InterruptedException caught in sync!";
+                logger.error(errMsg, e);
+                Assert.fail(errMsg);
+            }
+        }
+
+        Assert.assertTrue(serverConnectProcessor.isConnected());
+        Assert.assertEquals(1, serverConnectProcessor.getConnectTimes());
+        Assert.assertEquals(invokeTimes, serverUserProcessor.getInvokeTimes());
+    }
+
+    @Test
+    public void testFuture() throws InterruptedException {
+        RequestBody req = new RequestBody(2, "hello world future");
+        for (int i = 0; i < invokeTimes; i++) {
+            try {
+                client.invokeWithFuture(addr, req, 3000).get();
+                Assert.fail("Should not reach here!");
+            } catch (InvokeServerException e) {
+                Assert.assertTrue(true);
+            } catch (RemotingException e) {
+                String errMsg = "RemotingException caught in future!";
+                logger.error(errMsg, e);
+                Assert.fail("Should not reach here!");
+            } catch (InterruptedException e) {
+                String errMsg = "InterruptedException caught in future!";
+                logger.error(errMsg, e);
+                Assert.fail(errMsg);
+            }
+        }
+        Assert.assertTrue(serverConnectProcessor.isConnected());
+        Assert.assertEquals(1, serverConnectProcessor.getConnectTimes());
+        Assert.assertEquals(invokeTimes, serverUserProcessor.getInvokeTimes());
+    }
+
+    @Test
+    public void testCallback() throws InterruptedException {
+        RequestBody req = new RequestBody(1, "hello world callback");
+        final List<Object> rets = new ArrayList<Object>(1);
+        for (int i = 0; i < invokeTimes; i++) {
+            final CountDownLatch latch = new CountDownLatch(1);
+            try {
+                client.invokeWithCallback(addr, req, new InvokeCallback() {
+                    Executor executor = Executors.newCachedThreadPool();
+
+                    @Override
+                    public void onResponse(Object result) {
+                        latch.countDown();
+                        Assert.fail("Should not reach here!");
+                    }
+
+                    @Override
+                    public void onException(Throwable e) {
+                        rets.add(e);
+                        latch.countDown();
+                    }
+
+                    @Override
+                    public Executor getExecutor() {
+                        return executor;
+                    }
+
+                }, 1000);
+
+            } catch (RemotingException e) {
+                latch.countDown();
+                String errMsg = "RemotingException caught in callback!";
+                logger.error(errMsg, e);
+                Assert.fail("Should not reach here!");
+            }
+            try {
+                latch.await();
+            } catch (InterruptedException e) {
+                String errMsg = "InterruptedException caught in callback!";
+                logger.error(errMsg, e);
+                Assert.fail(errMsg);
+            }
+            if (rets.size() == 0) {
+                Assert.fail("No result! Maybe exception caught!");
+            }
+            Assert.assertEquals(InvokeServerException.class, rets.get(0).getClass());
+            rets.clear();
+        }
+
+        Assert.assertTrue(serverConnectProcessor.isConnected());
+        Assert.assertEquals(1, serverConnectProcessor.getConnectTimes());
+        Assert.assertEquals(invokeTimes, serverUserProcessor.getInvokeTimes());
+    }
+}

--- a/src/test/java/com/alipay/remoting/rpc/exception/BasicUsage_AsyncProcessor_ExceptionV2_Test.java
+++ b/src/test/java/com/alipay/remoting/rpc/exception/BasicUsage_AsyncProcessor_ExceptionV2_Test.java
@@ -40,18 +40,20 @@ import java.util.concurrent.Executors;
  * @author welkin.xu
  */
 public class BasicUsage_AsyncProcessor_ExceptionV2_Test {
-    static Logger logger = LoggerFactory.getLogger(BasicUsage_AsyncProcessor_ExceptionV2_Test.class);
+    static Logger            logger                    = LoggerFactory
+                                                           .getLogger(BasicUsage_AsyncProcessor_ExceptionV2_Test.class);
 
-    BoltServer server;
-    RpcClient  client;
+    BoltServer               server;
+    RpcClient                client;
 
-    int    port = PortScan.select();
-    String addr = "127.0.0.1:" + port;
+    int                      port                      = PortScan.select();
+    String                   addr                      = "127.0.0.1:" + port;
 
-    int invokeTimes = 5;
+    int                      invokeTimes               = 5;
 
-    AsyncServerUserProcessor serverUserProcessor       = new AsyncServerUserProcessor(true, true, false);
-    AsyncClientUserProcessor clientUserProcessor       = new AsyncClientUserProcessor( true, false);
+    AsyncServerUserProcessor serverUserProcessor       = new AsyncServerUserProcessor(true, true,
+                                                           false);
+    AsyncClientUserProcessor clientUserProcessor       = new AsyncClientUserProcessor(true, false);
     CONNECTEventProcessor    clientConnectProcessor    = new CONNECTEventProcessor();
     CONNECTEventProcessor    serverConnectProcessor    = new CONNECTEventProcessor();
     DISCONNECTEventProcessor clientDisConnectProcessor = new DISCONNECTEventProcessor();


### PR DESCRIPTION
async context support send exception, make the async processor keep the same exception handling semantics as the sync processor。releated [issue](https://github.com/sofastack/sofa-bolt/issues/317)