### PR TITLE
Fix: sendResponse if RpcRequestProcessor.doProcess throw Throwable 

### DIFF
--- a/src/main/java/com/alipay/remoting/rpc/protocol/RpcRequestProcessor.java
+++ b/src/main/java/com/alipay/remoting/rpc/protocol/RpcRequestProcessor.java
@@ -395,11 +395,11 @@ public class RpcRequestProcessor extends AbstractRemotingProcessor<RpcRequestCom
                 //protect the thread running this task
                 String remotingAddress = RemotingUtil.parseRemoteAddress(ctx.getChannelContext()
                     .channel());
-                logger
-                    .error(
-                        "Exception caught when process rpc request command in RpcRequestProcessor, Id="
-                                + msg.getId() + "! Invoke source address is [" + remotingAddress
-                                + "].", e);
+                String errMsg = "Exception caught when process rpc request command in RpcRequestProcessor, Id="
+                                + msg.getId();
+                logger.error(errMsg + "! Invoke source address is [" + remotingAddress + "].", e);
+                sendResponseIfNecessary(ctx, msg.getType(), getCommandFactory()
+                    .createExceptionResponse(msg.getId(), e, errMsg));
             }
         }
 

--- a/src/test/java/com/alipay/remoting/rpc/exception/ExceptionTest.java
+++ b/src/test/java/com/alipay/remoting/rpc/exception/ExceptionTest.java
@@ -354,6 +354,9 @@ public class ExceptionTest {
         RequestBody req = new RequestBody(4, "hello world");
         try {
             client.invokeSync(addr, req, 3000);
+            String errMsg = "Should throw InvokeServerException!";
+            logger.error(errMsg);
+            Assert.fail(errMsg);
         } catch (InvokeServerException e) {
             Assert.assertTrue(true);
         } catch (RemotingException e) {

--- a/src/test/java/com/alipay/remoting/rpc/exception/ExceptionTest.java
+++ b/src/test/java/com/alipay/remoting/rpc/exception/ExceptionTest.java
@@ -352,21 +352,15 @@ public class ExceptionTest {
         });
 
         RequestBody req = new RequestBody(4, "hello world");
+        Object result = null;
         try {
-            client.invokeSync(addr, req, 3000);
+            result = client.invokeSync(addr, req, 3000);
             String errMsg = "Should throw InvokeServerException!";
             logger.error(errMsg);
             Assert.fail(errMsg);
-        } catch (InvokeServerException e) {
-            Assert.assertTrue(true);
-        } catch (RemotingException e) {
-            String errMsg = "RemotingException in testGetBizClassLoaderException1";
-            logger.error(errMsg);
-            Assert.fail(errMsg);
-        } catch (InterruptedException e) {
-            String errMsg = "InterruptedException caught in testGetBizClassLoaderException1";
-            logger.error(errMsg, e);
-            Assert.fail(errMsg);
+        } catch (Exception e) {
+            Assert.assertNull(result);
+            Assert.assertEquals(InvokeServerException.class, e.getClass());
         }
     }
 }

--- a/src/test/java/com/alipay/remoting/rpc/exception/ExceptionTest.java
+++ b/src/test/java/com/alipay/remoting/rpc/exception/ExceptionTest.java
@@ -341,4 +341,29 @@ public class ExceptionTest {
         latch.await();
         Assert.assertEquals(InvokeServerException.class, ret.get(0).getClass());
     }
+
+    @Test
+    public void testGetBizClassLoaderException1() {
+        server.registerUserProcessor(new SimpleServerUserProcessor() {
+            @Override
+            public ClassLoader getBizClassLoader() {
+                throw new RuntimeException("getBizClassLoader fail.");
+            }
+        });
+
+        RequestBody req = new RequestBody(4, "hello world");
+        try {
+            client.invokeSync(addr, req, 3000);
+        } catch (InvokeServerException e) {
+            Assert.assertTrue(true);
+        } catch (RemotingException e) {
+            String errMsg = "RemotingException in testGetBizClassLoaderException1";
+            logger.error(errMsg);
+            Assert.fail(errMsg);
+        } catch (InterruptedException e) {
+            String errMsg = "InterruptedException caught in testGetBizClassLoaderException1";
+            logger.error(errMsg, e);
+            Assert.fail(errMsg);
+        }
+    }
 }


### PR DESCRIPTION
Fix: sendResponse if RpcRequestProcessor.doProcess throw Throwable in ProcessTask

### reproduce problem

`class ExceptionTest`
```
 @Test
    public void testGetBizClassLoaderException1() {
        server.registerUserProcessor(new SimpleServerUserProcessor() {
            @Override
            public ClassLoader getBizClassLoader() {
                throw new RuntimeException("getBizClassLoader fail.");
            }
        });

        RequestBody req = new RequestBody(4, "hello world");
        try {
            client.invokeSync(addr, req, 3000);
        } catch (InvokeServerException e) {
            Assert.assertTrue(true);
        } catch (RemotingException e) {
            String errMsg = "RemotingException in testGetBizClassLoaderException1";
            logger.error(errMsg);
            Assert.fail(errMsg);
        } catch (InterruptedException e) {
            String errMsg = "InterruptedException caught in testGetBizClassLoaderException1";
            logger.error(errMsg, e);
            Assert.fail(errMsg);
        }
    }
```

we except get InvokeServerException when userProcessor.getBizClassLoader throw exception.
but we get  InvokeTimeoutException
<img width="1045" alt="image" src="https://github.com/sofastack/sofa-bolt/assets/12369652/4c4176cc-87cc-4e6e-a074-02f8dc1273f5">


### The Reason

https://github.com/sofastack/sofa-bolt/blob/master/src/main/java/com/alipay/remoting/rpc/protocol/RpcRequestProcessor.java#L395

RpcRequestProcessor#ProcessTask did not handle Throwable. 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Refactor**
	- Improved the error logging mechanism for enhanced clarity and consistency in handling RPC requests.
- **Tests**
	- Added tests for handling exceptions when accessing the business class loader, ensuring robust error management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->