### PR TITLE
Fix: serialize exception response

### DIFF
--- a/src/main/java/com/alipay/remoting/rpc/protocol/RpcRequestProcessor.java
+++ b/src/main/java/com/alipay/remoting/rpc/protocol/RpcRequestProcessor.java
@@ -179,6 +179,12 @@ public class RpcRequestProcessor extends AbstractRemotingProcessor<RpcRequestCom
                 logger.error(errMsg, t);
                 serializedResponse = this.getCommandFactory()
                     .createExceptionResponse(id, t, errMsg);
+                try {
+                    serializedResponse.serialize();// serialize again for exception response
+                } catch (Throwable t1) {
+                    // should not happen
+                    logger.error("serialize exception response failed!", t1);
+                }
             }
 
             ctx.writeAndFlush(serializedResponse).addListener(new ChannelFutureListener() {


### PR DESCRIPTION
## Why make this change?

https://github.com/sofastack/sofa-bolt/blob/master/src/main/java/com/alipay/remoting/rpc/protocol/RpcRequestProcessor.java#L180

response forgot to serialize

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved exception handling in RPC requests by adding serialization of responses for exceptions, along with error logging for serialization failures.
- **Tests**
	- Added tests to verify the handling of `Throwable` during response serialization, ensuring robust error management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->