### PR TITLE
improve: RpcInvokeCallbackListener resolve response

### DIFF
--- a/src/main/java/com/alipay/remoting/rpc/RpcInvokeCallbackListener.java
+++ b/src/main/java/com/alipay/remoting/rpc/RpcInvokeCallbackListener.java
@@ -127,9 +127,9 @@ public class RpcInvokeCallbackListener implements InvokeCallbackListener {
                         Thread.currentThread().setContextClassLoader(future.getAppClassLoader());
                     }
 
+                    response.setInvokeContext(future.getInvokeContext());
                     Object responseObj = RpcResponseResolver.resolveResponseObject(response,
                         this.remoteAddress);
-                    response.setInvokeContext(future.getInvokeContext());
                     try {
                         callback.onResponse(responseObj);
                     } catch (Throwable e) {

--- a/src/main/java/com/alipay/remoting/rpc/RpcInvokeCallbackListener.java
+++ b/src/main/java/com/alipay/remoting/rpc/RpcInvokeCallbackListener.java
@@ -21,14 +21,8 @@ import java.util.concurrent.RejectedExecutionException;
 import com.alipay.remoting.*;
 import org.slf4j.Logger;
 
-import com.alipay.remoting.exception.CodecException;
-import com.alipay.remoting.exception.ConnectionClosedException;
 import com.alipay.remoting.log.BoltLoggerFactory;
 import com.alipay.remoting.rpc.exception.InvokeException;
-import com.alipay.remoting.rpc.exception.InvokeServerBusyException;
-import com.alipay.remoting.rpc.exception.InvokeServerException;
-import com.alipay.remoting.rpc.exception.InvokeTimeoutException;
-import com.alipay.remoting.rpc.protocol.RpcResponseCommand;
 
 /**
  * Listener which listens the Rpc invoke result, and then invokes the call back.
@@ -126,15 +120,15 @@ public class RpcInvokeCallbackListener implements InvokeCallbackListener {
                                               + ResponseStatus.UNKNOWN, future.getCause());
                 }
 
-                Object responseObj = RpcResponseResolver.resolveResponseObject(response,
-                    this.remoteAddress);
-
                 ClassLoader oldClassLoader = null;
                 try {
                     if (future.getAppClassLoader() != null) {
                         oldClassLoader = Thread.currentThread().getContextClassLoader();
                         Thread.currentThread().setContextClassLoader(future.getAppClassLoader());
                     }
+
+                    Object responseObj = RpcResponseResolver.resolveResponseObject(response,
+                        this.remoteAddress);
                     response.setInvokeContext(future.getInvokeContext());
                     try {
                         callback.onResponse(responseObj);
@@ -159,6 +153,7 @@ public class RpcInvokeCallbackListener implements InvokeCallbackListener {
                         .error(
                             "Exception occurred in user defined InvokeCallback#onException() logic, The address is {}",
                             this.remoteAddress, te);
+                    // Consider rethrowing the exception or handling it according to your application's needs
                 }
             }
 


### PR DESCRIPTION
## Why make this change?

The code for resolve response is duplicated。

replace duplicated code  by using `RpcResponseResolver.resolveResponseObject` method

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Implemented a new workflow for building and releasing the Java project using Maven.
  - Added new methods for writing, flushing, and cloning `RemotingContext` instances.

- **Bug Fixes**
  - Fixed the `isFine()` method in `Connection` to properly check the closed status.

- **Improvements**
  - Refactored `CallbackTask` class to enhance exception handling, error messages, and callback invocation logic.
  - Updated various dependency versions in `pom.xml` for improved stability and performance.
  - Renamed variables in `BaseRemoting` for better clarity.
  - Added thread safety in `SerializerManager`.

- **Tests**
  - Added new test methods to improve coverage for connection handling, exception testing, and RPC command processing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->