### PR TITLE
improve: write and flush methods are provided

### DIFF
--- a/src/main/java/com/alipay/remoting/RemotingContext.java
+++ b/src/main/java/com/alipay/remoting/RemotingContext.java
@@ -105,11 +105,29 @@ public class RemotingContext {
     /**
      * Wrap the writeAndFlush method.
      * 
-     * @param msg
-     * @return
+     * @param msg as msg
+     * @return channel future
      */
     public ChannelFuture writeAndFlush(RemotingCommand msg) {
         return this.channelContext.writeAndFlush(msg);
+    }
+
+    /**
+     * Wrap the write method.
+     *
+     * @param msg as msg
+     * @return channel future
+     */
+    public ChannelFuture write(RemotingCommand msg) {
+        return this.channelContext.write(msg);
+    }
+
+    /**
+     * Wrap the write method.
+     *
+     */
+    public void flush() {
+        this.channelContext.flush();
     }
 
     /**


### PR DESCRIPTION
https://github.com/funky-eyes/redispike-proxy
自己写的一个解析redis协议写入aerospike的代理程序，依赖sofa-bolt。支持redispippline时，需要批量响应，接收N个消息后，需要最后一个消息写完再flush，而sofa-bolt目前无法直接调用到write和单独的flush故此pr开放相关功能，并且利用这个功能，理论上也可以优化吞吐量，比如dubbo3.2的10倍性能提升就是通过先投入内存队列，然后异步从队列pop，将队列中同一时刻的请求全部先write，然后执行flush。
直接使用ctx#getChannelContext 粒度有点大，也不太优雅

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced the remoting operations with new methods to improve clarity and structure in handling data transmission.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->