### PR TITLE
Fix ProtocolCodeBasedDecoder memory leak

### DIFF
--- a/src/main/java/com/alipay/remoting/codec/ProtocolCodeBasedDecoder.java
+++ b/src/main/java/com/alipay/remoting/codec/ProtocolCodeBasedDecoder.java
@@ -106,7 +106,7 @@ public class ProtocolCodeBasedDecoder extends AbstractBatchDecoder {
 
             if (protocol == null) {
                 throw new CodecException("Unknown protocol code: [" + protocolCode
-                        + "] while decode in ProtocolDecoder.");
+                                         + "] while decode in ProtocolDecoder.");
             }
 
             protocol.getDecoder().decode(ctx, in, out);

--- a/src/main/java/com/alipay/remoting/codec/ProtocolCodeBasedDecoder.java
+++ b/src/main/java/com/alipay/remoting/codec/ProtocolCodeBasedDecoder.java
@@ -104,6 +104,7 @@ public class ProtocolCodeBasedDecoder extends AbstractBatchDecoder {
         }
 
         if (protocol == null) {
+            in.release();
             throw new CodecException("Unknown protocol code: [" + protocolCode
                                      + "] while decode in ProtocolDecoder.");
         }

--- a/src/test/java/com/alipay/remoting/codec/ProtocolCodeBasedDecoderTest.java
+++ b/src/test/java/com/alipay/remoting/codec/ProtocolCodeBasedDecoderTest.java
@@ -33,7 +33,6 @@ import io.netty.channel.EventLoop;
 import io.netty.channel.embedded.EmbeddedChannel;
 import io.netty.util.Attribute;
 import io.netty.util.AttributeKey;
-import io.netty.util.ResourceLeakDetector;
 import io.netty.util.concurrent.EventExecutor;
 import org.junit.Assert;
 import org.junit.Test;
@@ -54,6 +53,7 @@ public class ProtocolCodeBasedDecoderTest {
         ProtocolCodeBasedDecoder decoder = new ProtocolCodeBasedDecoder(1);
 
         int readerIndex = byteBuf.readerIndex();
+        int readableBytes = byteBuf.readableBytes();
         Assert.assertEquals(0, readerIndex);
 
         Exception exception = null;
@@ -67,13 +67,11 @@ public class ProtocolCodeBasedDecoderTest {
         Assert.assertNotNull(exception);
 
         readerIndex = byteBuf.readerIndex();
-        Assert.assertEquals(0, readerIndex);
+        Assert.assertEquals(readableBytes, readerIndex);
     }
 
     @Test
     public void testDecodeIllegalPacket2() {
-        ResourceLeakDetector.setLevel(ResourceLeakDetector.Level.PARANOID);
-
         EmbeddedChannel channel = new EmbeddedChannel();
         ProtocolCodeBasedDecoder decoder = new ProtocolCodeBasedDecoder(1);
         channel.pipeline().addLast(decoder);
@@ -82,6 +80,7 @@ public class ProtocolCodeBasedDecoderTest {
         byteBuf.writeByte((byte) 13);
 
         int readerIndex = byteBuf.readerIndex();
+        int readableBytes = byteBuf.readableBytes();
         Assert.assertEquals(0, readerIndex);
         Exception exception = null;
         try {
@@ -92,7 +91,7 @@ public class ProtocolCodeBasedDecoderTest {
         }
         Assert.assertNotNull(exception);
         readerIndex = byteBuf.readerIndex();
-        Assert.assertEquals(0, readerIndex);
+        Assert.assertEquals(readableBytes, readerIndex);
 
         Assert.assertTrue(byteBuf.refCnt() == 0);
     }


### PR DESCRIPTION
reproduce code
```
    @Test
    public void testDecodeIllegalPacket2() {
        EmbeddedChannel channel = new EmbeddedChannel();
        ProtocolCodeBasedDecoder decoder = new ProtocolCodeBasedDecoder(1);
        channel.pipeline().addLast(decoder);

        ByteBuf byteBuf = ByteBufAllocator.DEFAULT.buffer(8);
        byteBuf.writeByte((byte) 13);

        int readerIndex = byteBuf.readerIndex();
      
        Assert.assertEquals(0, readerIndex);
        Exception exception = null;
        try {
            channel.writeInbound(byteBuf);
        } catch (Exception e) {
            // ignore
            exception = e;
        }
        Assert.assertNotNull(exception);
        Assert.assertTrue(byteBuf.refCnt() == 0);
    }
```

when `ProtocolCodeBasedDecoder#decode()` throw exception . ByteBuf param  not released

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced error handling for decoding processes, improving robustness against unexpected input.
	- Introduced a new test case to improve coverage for decoder interactions with illegal packets.

- **Bug Fixes**
	- Ensured consistent state of the buffer after exception handling during decoding operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->