### PR TITLE
feat: support fury serializer

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -87,6 +87,7 @@
         <slf4j.version>1.7.21</slf4j.version>
         <sofa.common.tools>1.4.0</sofa.common.tools>
         <sortpom.maven.plugin>2.4.0</sortpom.maven.plugin>
+        <fury.version>0.6.0</fury.version>
     </properties>
 
     <dependencies>
@@ -95,6 +96,12 @@
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
             <version>${slf4j.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.fury</groupId>
+            <artifactId>fury-core</artifactId>
+            <version>${fury.version}</version>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>io.netty</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -67,6 +67,7 @@
         <cobertura.maven.plugin>2.6</cobertura.maven.plugin>
         <coveralls.maven.plugin>3.2.1</coveralls.maven.plugin>
         <disruptor.verion>3.4.4</disruptor.verion>
+        <fury.version>0.6.0</fury.version>
         <hessian.version>3.5.3</hessian.version>
         <java.version>1.8</java.version>
         <junit.version>4.13.1</junit.version>
@@ -87,7 +88,6 @@
         <slf4j.version>1.7.21</slf4j.version>
         <sofa.common.tools>1.4.0</sofa.common.tools>
         <sortpom.maven.plugin>2.4.0</sortpom.maven.plugin>
-        <fury.version>0.6.0</fury.version>
     </properties>
 
     <dependencies>

--- a/src/main/java/com/alipay/remoting/serialization/HessianSerializer.java
+++ b/src/main/java/com/alipay/remoting/serialization/HessianSerializer.java
@@ -34,12 +34,8 @@ import com.caucho.hessian.io.SerializerFactory;
 public class HessianSerializer implements Serializer {
 
     private SerializerFactory                         serializerFactory    = new SerializerFactory();
-    private static ThreadLocal<ByteArrayOutputStream> localOutputByteArray = new ThreadLocal<ByteArrayOutputStream>() {
-                                                                               @Override
-                                                                               protected ByteArrayOutputStream initialValue() {
-                                                                                   return new ByteArrayOutputStream();
-                                                                               }
-                                                                           };
+    private static ThreadLocal<ByteArrayOutputStream> localOutputByteArray = ThreadLocal.withInitial(
+            ByteArrayOutputStream::new);
 
     /** 
      * @see com.alipay.remoting.serialization.Serializer#serialize(java.lang.Object)

--- a/src/main/java/com/alipay/remoting/serialization/SerializerManager.java
+++ b/src/main/java/com/alipay/remoting/serialization/SerializerManager.java
@@ -36,7 +36,7 @@ public class SerializerManager {
 
     //public static final byte    Json        = 2;
 
-    public static final byte           Fury       = 3;
+    public static final byte           Fury           = 3;
 
     private static final ReentrantLock REENTRANT_LOCK = new ReentrantLock();
 

--- a/src/main/java/com/alipay/remoting/serialization/SerializerManager.java
+++ b/src/main/java/com/alipay/remoting/serialization/SerializerManager.java
@@ -17,6 +17,7 @@
 package com.alipay.remoting.serialization;
 
 import java.util.concurrent.locks.ReentrantLock;
+import com.alipay.remoting.serialization.fury.FurySerializer;
 
 /**
  * Manage all serializers.
@@ -32,19 +33,27 @@ public class SerializerManager {
 
     private static Serializer[]        serializers    = new Serializer[5];
     public static final byte           Hessian2       = 1;
+
     //public static final byte    Json        = 2;
+
+    public static final byte           Fury       = 3;
 
     private static final ReentrantLock REENTRANT_LOCK = new ReentrantLock();
 
     public static Serializer getSerializer(int idx) {
         Serializer currentSerializer = serializers[idx];
-        if (currentSerializer == null && idx == Hessian2) {
+        if (currentSerializer == null) {
             REENTRANT_LOCK.lock();
             try {
                 currentSerializer = serializers[idx];
                 if (currentSerializer == null) {
-                    currentSerializer = new HessianSerializer();
-                    addSerializer(Hessian2, currentSerializer);
+                    if (idx == Hessian2) {
+                        currentSerializer = new HessianSerializer();
+                        addSerializer(Hessian2, currentSerializer);
+                    } else if (idx == Fury) {
+                        currentSerializer = new FurySerializer();
+                        addSerializer(Fury, currentSerializer);
+                    }
                 }
             } finally {
                 REENTRANT_LOCK.unlock();

--- a/src/main/java/com/alipay/remoting/serialization/fury/FurySerializer.java
+++ b/src/main/java/com/alipay/remoting/serialization/fury/FurySerializer.java
@@ -1,0 +1,68 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alipay.remoting.serialization.fury;
+
+import java.util.ArrayList;
+import java.util.List;
+import com.alipay.remoting.exception.CodecException;
+import com.alipay.remoting.serialization.Serializer;
+import org.apache.fury.Fury;
+import org.apache.fury.collection.Tuple2;
+import org.apache.fury.config.Language;
+import org.apache.fury.memory.MemoryBuffer;
+import org.apache.fury.memory.MemoryUtils;
+import org.apache.fury.util.LoaderBinding;
+
+/**
+ * @author jianbin@apache.org
+ */
+public class FurySerializer implements Serializer {
+
+    private static final List<Class<?>> REGISTRY_LIST = new ArrayList<>();
+
+    private static final ThreadLocal<Tuple2<LoaderBinding, MemoryBuffer>> furyFactory = ThreadLocal.withInitial(() -> {
+        LoaderBinding binding = new LoaderBinding(classLoader ->{
+            Fury fury = Fury.builder().withRefTracking(true)
+            .requireClassRegistration(true).withClassLoader(classLoader).build();
+            REGISTRY_LIST.forEach(fury::register);
+            return fury;
+        });
+        MemoryBuffer buffer = MemoryUtils.buffer(32);
+        return Tuple2.of(binding, buffer);
+    });
+
+    @Override
+    public byte[] serialize(Object obj) throws CodecException {
+        Tuple2<LoaderBinding, MemoryBuffer> tuple2 = furyFactory.get();
+        tuple2.f0.setClassLoader(Thread.currentThread().getContextClassLoader());
+        Fury fury = tuple2.f0.get();
+        return fury.serialize(obj);
+    }
+
+    @Override
+    public <T> T deserialize(byte[] data, String classOfT) throws CodecException {
+        Tuple2<LoaderBinding, MemoryBuffer> tuple2 = furyFactory.get();
+        tuple2.f0.setClassLoader(Thread.currentThread().getContextClassLoader());
+        Fury fury = tuple2.f0.get();
+        return (T)fury.deserialize(data);
+    }
+
+    public static void registry(Class<?> clazz) {
+        REGISTRY_LIST.add(clazz);
+    }
+
+}

--- a/src/test/java/com/alipay/remoting/serialization/fury/FurySerializerTest.java
+++ b/src/test/java/com/alipay/remoting/serialization/fury/FurySerializerTest.java
@@ -1,0 +1,77 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alipay.remoting.serialization.fury;
+
+import java.util.UUID;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import com.alipay.remoting.serialization.HessianSerializerTest;
+import org.apache.fury.Fury;
+import org.apache.fury.config.Language;
+
+import com.alipay.remoting.exception.CodecException;
+import com.alipay.remoting.serialization.Serializer;
+import org.junit.Test;
+
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+/**
+ * @author jianbin@apache.org
+ */
+public class FurySerializerTest{
+
+    public static FurySerializer serializer = new FurySerializer();
+
+    @Test
+    public void concurrentSerializeTest() throws InterruptedException {
+        int concurrentNum = 10;
+        CountDownLatch countDownLatch = new CountDownLatch(concurrentNum);
+        for (int i = 0; i < concurrentNum; ++i) {
+            FurySerializerTest.MyThread thread = new FurySerializerTest.MyThread(countDownLatch);
+            new Thread(thread).start();
+        }
+        countDownLatch.await(2, TimeUnit.SECONDS);
+
+    }
+
+    static class MyThread implements Runnable {
+        CountDownLatch countDownLatch;
+
+        public MyThread(CountDownLatch countDownLatch) {
+            this.countDownLatch = countDownLatch;
+        }
+
+        @Override
+        public void run() {
+            try {
+                for (int i = 0; i < 100; i++) {
+                    String randomStr = UUID.randomUUID().toString();
+                    byte[] bytes = serializer.serialize(randomStr);
+                    String o = serializer.deserialize(bytes, String.class.getName());
+                    assertEquals(o, randomStr);
+                }
+            } catch (Exception e) {
+                fail();
+            } finally {
+                countDownLatch.countDown();
+            }
+        }
+    }
+
+}

--- a/src/test/java/com/alipay/remoting/serialization/fury/FurySerializerTest.java
+++ b/src/test/java/com/alipay/remoting/serialization/fury/FurySerializerTest.java
@@ -26,14 +26,13 @@ import org.apache.fury.exception.InsecureException;
 import org.junit.Assert;
 import org.junit.Test;
 
-
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 
 /**
  * @author jianbin@apache.org
  */
-public class FurySerializerTest{
+public class FurySerializerTest {
 
     public static FurySerializer serializer;
 


### PR DESCRIPTION
个人认为apache fury已经进入apache孵化器,未来的迭代,稳定性也会更高,性能根据其测试报告非常优秀,并且目前sofa-bolt自带的序列化器只有hessian,应该扩充一些序列化器避免用户自行实现.
目前pr中遗留2个问题需要跟社区讨论下:
1. 是否将fury的白名单关闭?(dubbo侧是直接关闭的,用户不需要手动注册类,但是有安全风险),目前的实现是开启白名单,也就是用户在使用fury序列化器时,需要在应用初始化时将需要rpc用到的类手动注册到fury中(专门为此开了一个静态方法以便使用)
2. 是否将hessian也开启白名单,如果二者都要开启白名单,那么应该抽象出一个专门用作白名单的类,在初始化二者时,自动将白名单涉及的类注册进去.(如果需要该能力,可以通过额外的pr来实现,该pr先只做fury的序列化支持)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
    - Introduced a new serializer, `FurySerializer`, enhancing serialization capabilities within the application.
    - Added support for version management of the Apache Fury library.

- **Bug Fixes**
    - Improved error handling in the serialization process to provide clearer messages for exceptions.

- **Tests**
    - Implemented a comprehensive suite of unit tests for the `FurySerializer`, validating successful and concurrent serialization scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->