### PR TITLE
bugfix: native-image AOT runtime GBK encoding error

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.alipay.sofa</groupId>
     <artifactId>bolt</artifactId>
-    <version>1.6.11</version>
+    <version>1.6.12-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>${project.groupId}:${project.artifactId}</name>

--- a/src/main/resources/com/alipay/remoting/log/log4j/log-conf.xml
+++ b/src/main/resources/com/alipay/remoting/log/log4j/log-conf.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="GBK"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE log4j:configuration SYSTEM "log4j.dtd">
 
 <!-- Log4j 1.x config -->

--- a/src/main/resources/com/alipay/remoting/log/log4j2/log-conf.xml
+++ b/src/main/resources/com/alipay/remoting/log/log4j2/log-conf.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="GBK"?>
+<?xml version="1.0" encoding="UTF-8"?>
 
 <!-- Log4j 2.x config -->
 <Configuration status="OFF">

--- a/src/main/resources/com/alipay/remoting/log/logback/log-conf.xml
+++ b/src/main/resources/com/alipay/remoting/log/logback/log-conf.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="GBK"?>
+<?xml version="1.0" encoding="UTF-8"?>
 
 <!-- Logback config -->
 <configuration>


### PR DESCRIPTION
```
Sofa-Middleware-Log:ERROR [com.alipay.remoting] Build ILoggerFactory error! Default app logger will be used.
java.lang.IllegalStateException: Logback loggerSpaceFactory build error
        at com.alipay.sofa.common.log.factory.LogbackLoggerSpaceFactory.<init>(LogbackLoggerSpaceFactory.java:73)
        at com.alipay.sofa.common.log.factory.LoggerSpaceFactory4LogbackBuilder.doBuild(LoggerSpaceFactory4LogbackBuilder.java:44)
        at com.alipay.sofa.common.log.factory.AbstractLoggerSpaceFactoryBuilder.build(AbstractLoggerSpaceFactoryBuilder.java:67)
        at com.alipay.sofa.common.log.MultiAppLoggerSpaceManager.createILoggerFactory(MultiAppLoggerSpaceManager.java:305)
        at com.alipay.sofa.common.log.MultiAppLoggerSpaceManager.getILoggerFactoryBySpaceName(MultiAppLoggerSpaceManager.java:194)
        at com.alipay.sofa.common.log.MultiAppLoggerSpaceManager.getLoggerBySpace(MultiAppLoggerSpaceManager.java:173)
        at com.alipay.sofa.common.log.LoggerSpaceManager.getLoggerBySpace(LoggerSpaceManager.java:101)
        at com.alipay.sofa.common.log.LoggerSpaceManager.getLoggerBySpace(LoggerSpaceManager.java:75)
        at com.alipay.sofa.common.log.LoggerSpaceManager.getLoggerBySpace(LoggerSpaceManager.java:46)
        at com.alipay.remoting.log.BoltLoggerFactory.getLogger(BoltLoggerFactory.java:86)
        at com.alipay.remoting.AbstractRemotingServer.<clinit>(AbstractRemotingServer.java:42)
        at java.base@23.0.1/java.lang.Class.ensureInitialized(DynamicHub.java:650)
        at icu.funkye.redispike.common.BoltServer.<init>(BoltServer.java:34)
        at icu.funkye.redispike.Server.start(Server.java:89)
        at icu.funkye.redispike.ProxyMain.main(ProxyMain.java:25)
        at java.base@23.0.1/java.lang.invoke.LambdaForm$DMH/sa346b79c.invokeStaticInit(LambdaForm$DMH)
Caused by: ch.qos.logback.core.joran.spi.JoranException: I/O error occurred while parsing xml file
        at ch.qos.logback.core.joran.event.SaxEventRecorder.handleError(SaxEventRecorder.java:74)
        at ch.qos.logback.core.joran.event.SaxEventRecorder.recordEvents(SaxEventRecorder.java:62)
        at ch.qos.logback.core.joran.GenericConfigurator.doConfigure(GenericConfigurator.java:151)
        at ch.qos.logback.core.joran.GenericConfigurator.doConfigure(GenericConfigurator.java:110)
        at ch.qos.logback.core.joran.GenericConfigurator.doConfigure(GenericConfigurator.java:53)
        at ch.qos.logback.classic.util.ContextInitializer.configureByResource(ContextInitializer.java:64)
        at com.alipay.sofa.common.log.factory.LogbackLoggerSpaceFactory.<init>(LogbackLoggerSpaceFactory.java:71)
        ... 15 more
Caused by: java.io.UnsupportedEncodingException: GBK
        at java.base@23.0.1/sun.nio.cs.StreamDecoder.forInputStreamReader(StreamDecoder.java:79)
        at java.base@23.0.1/java.io.InputStreamReader.<init>(InputStreamReader.java:113)
        at java.xml@23.0.1/com.sun.org.apache.xerces.internal.impl.XMLEntityScanner.createReader(XMLEntityScanner.java:1858)
        at java.xml@23.0.1/com.sun.org.apache.xerces.internal.impl.XMLEntityScanner.setEncoding(XMLEntityScanner.java:479)
        at java.xml@23.0.1/com.sun.org.apache.xerces.internal.impl.XMLDocumentFragmentScannerImpl.scanXMLDeclOrTextDecl(XMLDocumentFragmentScannerImpl.java:1033)
        at java.xml@23.0.1/com.sun.org.apache.xerces.internal.impl.XMLDocumentScannerImpl$XMLDeclDriver.next(XMLDocumentScannerImpl.java:782)
        at java.xml@23.0.1/com.sun.org.apache.xerces.internal.impl.XMLDocumentScannerImpl.next(XMLDocumentScannerImpl.java:635)
        at java.xml@23.0.1/com.sun.org.apache.xerces.internal.impl.XMLNSDocumentScannerImpl.next(XMLNSDocumentScannerImpl.java:113)
        at java.xml@23.0.1/com.sun.org.apache.xerces.internal.impl.XMLDocumentFragmentScannerImpl.scanDocument(XMLDocumentFragmentScannerImpl.java:482)
        at java.xml@23.0.1/com.sun.org.apache.xerces.internal.parsers.XML11Configuration.parse(XML11Configuration.java:890)
        at java.xml@23.0.1/com.sun.org.apache.xerces.internal.parsers.XML11Configuration.parse(XML11Configuration.java:826)
        at java.xml@23.0.1/com.sun.org.apache.xerces.internal.parsers.XMLParser.parse(XMLParser.java:134)
        at java.xml@23.0.1/com.sun.org.apache.xerces.internal.parsers.AbstractSAXParser.parse(AbstractSAXParser.java:1225)
        at java.xml@23.0.1/com.sun.org.apache.xerces.internal.jaxp.SAXParserImpl$JAXPSAXParser.parse(SAXParserImpl.java:643)
        at java.xml@23.0.1/com.sun.org.apache.xerces.internal.jaxp.SAXParserImpl.parse(SAXParserImpl.java:326)
        at ch.qos.logback.core.joran.event.SaxEventRecorder.recordEvents(SaxEventRecorder.java:59)
        ... 20 more
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Version Update**
	- Updated project version from `1.6.11` to `1.6.12-SNAPSHOT`

- **Configuration**
	- Updated Logback logging configuration to use UTF-8 encoding
	- Updated Log4j logging configuration to use UTF-8 encoding
	- Updated Log4j 2.x logging configuration to use UTF-8 encoding
<!-- end of auto-generated comment: release notes by coderabbit.ai -->