### PR TITLE
fix: improve isNumeric method to check for blank strings

### DIFF
--- a/src/main/java/com/alipay/remoting/util/StringUtils.java
+++ b/src/main/java/com/alipay/remoting/util/StringUtils.java
@@ -18,6 +18,7 @@ package com.alipay.remoting.util;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 
 /**
  * Created by zhangg on 2016/7/14 21:07.
@@ -116,6 +117,6 @@ public class StringUtils {
     }
 
     public static boolean equals(String str1, String str2) {
-        return str1 == null ? str2 == null : str1.equals(str2);
+        return Objects.equals(str1, str2);
     }
 }

--- a/src/main/java/com/alipay/remoting/util/StringUtils.java
+++ b/src/main/java/com/alipay/remoting/util/StringUtils.java
@@ -100,7 +100,7 @@ public class StringUtils {
     }
 
     public static boolean isNumeric(String str) {
-        if (str == null) {
+        if (isBlank(str)) {
             return false;
         } else {
             int sz = str.length();

--- a/src/test/java/com/alipay/remoting/inner/utiltest/StringUtilsTest.java
+++ b/src/test/java/com/alipay/remoting/inner/utiltest/StringUtilsTest.java
@@ -74,7 +74,7 @@ public class StringUtilsTest {
         Assert.assertTrue(StringUtils.isNumeric("11"));
         Assert.assertFalse(StringUtils.isNumeric("1a1"));
         Assert.assertFalse(StringUtils.isNumeric("aa"));
-        Assert.assertTrue(StringUtils.isNumeric(""));
+        Assert.assertFalse(StringUtils.isNumeric(""));
         Assert.assertFalse(StringUtils.isNumeric("  "));
         Assert.assertFalse(StringUtils.isNumeric(" a "));
         Assert.assertFalse(StringUtils.isNumeric("  123  "));


### PR DESCRIPTION
空字符串是无法被转为number类型的，而这里的isNumeric方法会认为空字符串是number类型。
An empty string cannot be converted to a number type, yet the isNumeric method considers an empty string as a number type.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved string comparison to handle null values more safely.
  - Updated numeric validation to correctly treat blank strings (null, empty, or whitespace only) as non-numeric.

- **Tests**
  - Adjusted tests to expect blank strings to be identified as non-numeric.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->