### PR TITLE
try to make the tests more stable

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -135,6 +135,18 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.awaitility</groupId>
+            <artifactId>awaitility</artifactId>
+            <version>4.3.0</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <version>4.11.0</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-core</artifactId>
             <version>${log4j.version}</version>


### PR DESCRIPTION
1. use Awaitility to make the unit tests more stable
2. use Mockito to mock some necessary objects
3. fix the potential concurrent race issue of remotingContextList

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Improved reliability of heartbeat and command handler tests by replacing static waits and latches with asynchronous waiting using Awaitility.
  - Enhanced concurrency handling in tests with thread-safe collections and realistic mocking.
  - Updated test dependencies to include Awaitility and Mockito for more robust asynchronous and mocking support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->