### PR TITLE
opt: connection returns the result after calling remove method

### DIFF
--- a/src/main/java/com/alipay/remoting/Connection.java
+++ b/src/main/java/com/alipay/remoting/Connection.java
@@ -351,8 +351,8 @@ public class Connection {
      *
      * @param poolKey connection pool key
      */
-    public void removePoolKey(String poolKey) {
-        poolKeys.remove(poolKey);
+    public boolean removePoolKey(String poolKey) {
+        return poolKeys.remove(poolKey);
     }
 
     /**
@@ -410,8 +410,8 @@ public class Connection {
      *
      * @param key attribute key
      */
-    public void removeAttribute(String key) {
-        attributes.remove(key);
+    public Object removeAttribute(String key) {
+        return attributes.remove(key);
     }
 
     /**


### PR DESCRIPTION
将原本removePoolKey和removeAttribute void类型改为对应方法的返回类型
比如做4层转发代理时，为了将client连接与upstream连接一对一绑定 会通过connection中setAttribute方法绑定一个channel。
当需要close upstream连接时 connection方法未将removeAttribute的返回值返回，导致需要先get后remove存在线程安全问题，比较麻烦。直接使用removeAttribute可保证线程安全下取消绑定关系，并对其返回值做额外处理，较为灵活。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * `removePoolKey` method now returns a boolean indicating whether the removal was successful
  * `removeAttribute` method now returns the removed attribute value

<!-- end of auto-generated comment: release notes by coderabbit.ai -->